### PR TITLE
Removing unneeded pass

### DIFF
--- a/src/bloqade/squin/groups.py
+++ b/src/bloqade/squin/groups.py
@@ -2,8 +2,6 @@ from kirin import ir, passes
 from kirin.prelude import structural_no_opt
 from kirin.dialects import ilist
 
-from bloqade.qasm2.rewrite.desugar import IndexingDesugarPass
-
 from . import op, wire, qubit
 
 
@@ -12,7 +10,6 @@ def kernel(self):
     fold_pass = passes.Fold(self)
     typeinfer_pass = passes.TypeInfer(self)
     ilist_desugar_pass = ilist.IListDesugar(self)
-    indexing_desugar_pass = IndexingDesugarPass(self)
 
     def run_pass(method, *, fold=True, typeinfer=True):
         method.verify()
@@ -22,7 +19,6 @@ def kernel(self):
         if typeinfer:
             typeinfer_pass(method)
         ilist_desugar_pass(method)
-        indexing_desugar_pass(method)
         if typeinfer:
             typeinfer_pass(method)  # fix types after desugaring
             method.code.typecheck()


### PR DESCRIPTION
Importing this pass from `qasm2` makes it so that the regular installation without the extras breaks because `lark` is not a part of the default list of dependencies. Also this pass is needed only for the `qasm2.core` dialect to add support for indexing of QRegisters which are not a part of squin. 