### PR TITLE
fix incorrect squin wire address type

### DIFF
--- a/src/bloqade/analysis/address/lattice.py
+++ b/src/bloqade/analysis/address/lattice.py
@@ -81,5 +81,5 @@ class AddressWire(Address):
 
     def is_subseteq(self, other: Address) -> bool:
         if isinstance(other, AddressWire):
-            return self.origin_qubit == self.origin_qubit
+            return self.origin_qubit == other.origin_qubit
         return False


### PR DESCRIPTION
I caught this when I was reviewing some old code, admittedly embarrassing not to have caught earlier 😅 