### PR TITLE
Fix some pyright issues

### DIFF
--- a/src/bloqade/analysis/address/impls.py
+++ b/src/bloqade/analysis/address/impls.py
@@ -191,12 +191,11 @@ class SquinWireMethodTable(interp.MethodTable):
     ):
 
         origin_qubit = frame.get(stmt.qubit)
-        
-        if isintance(origin_qubit, AddressQubit):
 
+        if isinstance(origin_qubit, AddressQubit):
             return (AddressWire(origin_qubit=origin_qubit),)
         else:
-            return (Address.top(), )
+            return (Address.top(),)
 
     @interp.impl(squin.wire.Apply)
     def apply(

--- a/src/bloqade/analysis/address/impls.py
+++ b/src/bloqade/analysis/address/impls.py
@@ -190,9 +190,13 @@ class SquinWireMethodTable(interp.MethodTable):
         stmt: squin.wire.Unwrap,
     ):
 
-        origin_qubit = frame.get_casted(stmt.qubit, AddressQubit)
+        origin_qubit = frame.get(stmt.qubit)
+        
+        if isintance(origin_qubit, AddressQubit):
 
-        return (AddressWire(origin_qubit=origin_qubit),)
+            return (AddressWire(origin_qubit=origin_qubit),)
+        else:
+            return (Address.top(), )
 
     @interp.impl(squin.wire.Apply)
     def apply(

--- a/src/bloqade/analysis/address/impls.py
+++ b/src/bloqade/analysis/address/impls.py
@@ -204,17 +204,7 @@ class SquinWireMethodTable(interp.MethodTable):
         frame: ForwardFrame[Address],
         stmt: squin.wire.Apply,
     ):
-
-        origin_qubits = tuple(
-            [
-                frame.get_casted(input_elem, AddressWire).origin_qubit
-                for input_elem in stmt.inputs
-            ]
-        )
-        new_address_wires = tuple(
-            [AddressWire(origin_qubit=origin_qubit) for origin_qubit in origin_qubits]
-        )
-        return new_address_wires
+        return frame.get_values(stmt.inputs)
 
 
 @squin.qubit.dialect.register(key="qubit.address")

--- a/src/bloqade/analysis/address/impls.py
+++ b/src/bloqade/analysis/address/impls.py
@@ -190,7 +190,7 @@ class SquinWireMethodTable(interp.MethodTable):
         stmt: squin.wire.Unwrap,
     ):
 
-        origin_qubit = frame.get(stmt.qubit)
+        origin_qubit = frame.get_casted(stmt.qubit, AddressQubit)
 
         return (AddressWire(origin_qubit=origin_qubit),)
 
@@ -203,7 +203,10 @@ class SquinWireMethodTable(interp.MethodTable):
     ):
 
         origin_qubits = tuple(
-            [frame.get(input_elem).origin_qubit for input_elem in stmt.inputs]
+            [
+                frame.get_casted(input_elem, AddressWire).origin_qubit
+                for input_elem in stmt.inputs
+            ]
         )
         new_address_wires = tuple(
             [AddressWire(origin_qubit=origin_qubit) for origin_qubit in origin_qubits]

--- a/src/bloqade/noise/native/model.py
+++ b/src/bloqade/noise/native/model.py
@@ -102,10 +102,9 @@ class MoveNoiseModelABC(abc.ABC):
     params: MoveNoiseParams = field(default_factory=MoveNoiseParams)
     """Parameters for calculating move noise."""
 
-    @classmethod
     @abc.abstractmethod
     def parallel_cz_errors(
-        cls, ctrls: List[int], qargs: List[int], rest: List[int]
+        self, ctrls: List[int], qargs: List[int], rest: List[int]
     ) -> Dict[Tuple[float, float, float, float], List[int]]:
         """Takes a set of ctrls and qargs and returns a noise model for all qubits."""
         pass

--- a/src/bloqade/qasm2/parse/lowering.py
+++ b/src/bloqade/qasm2/parse/lowering.py
@@ -85,6 +85,10 @@ class QASM2(lowering.LoweringABC[ast.Node]):
             stmt = expr.ConstInt(value=value)
         elif isinstance(value, float):
             stmt = expr.ConstFloat(value=value)
+        else:
+            raise lowering.BuildError(
+                f"Expected value of type float or int, got {type(value)}."
+            )
         state.current_frame.push(stmt)
         return stmt.result
 
@@ -99,6 +103,8 @@ class QASM2(lowering.LoweringABC[ast.Node]):
             dialects = ["qasm2.core", "qasm2.uop", "qasm2.expr"]
         elif isinstance(node.header, ast.Kirin):
             dialects = node.header.dialects
+        else:
+            raise lowering.BuildError(f"Unexpected node header {node.header}")
 
         for dialect in dialects:
             if dialect not in allowed:
@@ -295,6 +301,8 @@ class QASM2(lowering.LoweringABC[ast.Node]):
             stmt = core.QRegGet(reg, addr.result)
         elif reg.type.is_subseteq(CRegType):
             stmt = core.CRegGet(reg, addr.result)
+        else:
+            raise lowering.BuildError(f"Unexpected register type {reg.type}")
         return state.current_frame.push(stmt).result
 
     def visit_Call(self, state: lowering.State[ast.Node], node: ast.Call):

--- a/src/bloqade/qasm2/passes/fold.py
+++ b/src/bloqade/qasm2/passes/fold.py
@@ -19,7 +19,7 @@ from kirin.rewrite import (
 from kirin.analysis import const
 from kirin.dialects import scf, ilist
 from kirin.ir.method import Method
-from kirin.rewrite.abc import RewriteResult
+from kirin.rewrite.result import RewriteResult
 
 from bloqade.qasm2.dialects import expr
 

--- a/src/bloqade/qasm2/rewrite/heuristic_noise.py
+++ b/src/bloqade/qasm2/rewrite/heuristic_noise.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Tuple
+from typing import Dict, List, Tuple, cast
 from dataclasses import field, dataclass
 
 from kirin import ir
@@ -226,8 +226,12 @@ class NoiseRewriteRule(result_abc.RewriteRule):
             and isinstance(qargs, address.AddressTuple)
             and all(isinstance(addr, address.AddressQubit) for addr in qargs.data)
         ):
-            ctrl_qubits = list(map(lambda addr: addr.data, ctrls.data))
-            qarg_qubits = list(map(lambda addr: addr.data, qargs.data))
+            ctrl_qubits = list(
+                map(lambda addr: cast(address.AddressQubit, addr).data, ctrls.data)
+            )
+            qarg_qubits = list(
+                map(lambda addr: cast(address.AddressQubit, addr).data, qargs.data)
+            )
             rest = sorted(
                 set(self.qubit_ssa_value.keys()) - set(ctrl_qubits + qarg_qubits)
             )

--- a/src/bloqade/qasm2/rewrite/native_gates.py
+++ b/src/bloqade/qasm2/rewrite/native_gates.py
@@ -279,7 +279,7 @@ class RydbergGateSetRewriteRule(abc.RewriteRule):
         lam = self._get_const_value(node.lam)
         phi = self._get_const_value(node.phi)
 
-        if not all((theta, phi, lam)):
+        if theta is None or lam is None or phi is None:
             return result.RewriteResult()
 
         # cirq.ControlledGate(u3(theta, lambda phi))

--- a/src/bloqade/qasm2/rewrite/native_gates.py
+++ b/src/bloqade/qasm2/rewrite/native_gates.py
@@ -70,7 +70,7 @@ class CU(cirq.Gate):
         return "*", "CU"
 
 
-def around(val):
+def around(val) -> float:
     return float(np.around(val, 14))
 
 
@@ -78,7 +78,7 @@ def one_qubit_gate_to_u3_angles(op: cirq.Operation) -> tuple[float, float, float
     lam, theta, phi = (  # Z angle, Y angle, then Z angle
         cirq.deconstruct_single_qubit_matrix_into_angles(cirq.unitary(op))
     )
-    return tuple(map(around, (theta, phi, lam)))
+    return around(theta), around(phi), around(lam)
 
 
 @dataclass

--- a/src/bloqade/qasm2/rewrite/register.py
+++ b/src/bloqade/qasm2/rewrite/register.py
@@ -1,6 +1,7 @@
 from kirin import ir
 from kirin.dialects import py
-from kirin.rewrite.abc import RewriteRule, RewriteResult
+from kirin.rewrite.abc import RewriteRule
+from kirin.rewrite.result import RewriteResult
 
 from bloqade.qasm2.dialects import core
 

--- a/src/bloqade/qbraid/schema.py
+++ b/src/bloqade/qbraid/schema.py
@@ -95,9 +95,7 @@ class Measurement(Operation, frozen=True):
     participants: Tuple[int, ...]
 
 
-OperationType = TypeVar(
-    "OperationType", bound=Union[CZ, GlobalRz, GlobalW, LocalRz, LocalW, Measurement]
-)
+OperationType = CZ | GlobalRz | GlobalW | LocalRz | LocalW | Measurement
 
 
 class ErrorModel(BaseModel, frozen=True, extra="forbid"):

--- a/src/bloqade/qbraid/schema.py
+++ b/src/bloqade/qbraid/schema.py
@@ -9,7 +9,7 @@ class Operation(BaseModel, frozen=True, extra="forbid"):
     op_type: str = Field(init=False)
 
 
-class CZ(Operation):
+class CZ(Operation, frozen=True):
     """A CZ gate operation.
 
     Fields:
@@ -22,7 +22,7 @@ class CZ(Operation):
     participants: Tuple[Union[Tuple[int], Tuple[int, int]], ...]
 
 
-class GlobalRz(Operation):
+class GlobalRz(Operation, frozen=True):
     """GlobalRz operation.
 
     Fields:
@@ -34,7 +34,7 @@ class GlobalRz(Operation):
     phi: float
 
 
-class GlobalW(Operation):
+class GlobalW(Operation, frozen=True):
     """GlobalW operation.
 
     Fields:
@@ -48,7 +48,7 @@ class GlobalW(Operation):
     phi: float
 
 
-class LocalRz(Operation):
+class LocalRz(Operation, frozen=True):
     """LocalRz operation.
 
     Fields:
@@ -63,7 +63,7 @@ class LocalRz(Operation):
     phi: float
 
 
-class LocalW(Operation):
+class LocalW(Operation, frozen=True):
     """LocalW operation.
 
     Fields:
@@ -80,7 +80,7 @@ class LocalW(Operation):
     phi: float
 
 
-class Measurement(Operation):
+class Measurement(Operation, frozen=True):
     """Measurement operation.
 
     Fields:
@@ -106,7 +106,7 @@ class ErrorModel(BaseModel, frozen=True, extra="forbid"):
     error_model_type: str = Field(init=False)
 
 
-class PauliErrorModel(ErrorModel):
+class PauliErrorModel(ErrorModel, frozen=True):
     """Pauli error model.
 
     Fields:
@@ -131,7 +131,7 @@ class ErrorOperation(BaseModel, Generic[ErrorModelType], frozen=True, extra="for
     survival_prob: Tuple[float, ...]
 
 
-class CZError(ErrorOperation[ErrorModelType]):
+class CZError(ErrorOperation[ErrorModelType], frozen=True):
     """CZError operation.
 
     Fields:
@@ -149,7 +149,7 @@ class CZError(ErrorOperation[ErrorModelType]):
     single_error: ErrorModelType
 
 
-class SingleQubitError(ErrorOperation[ErrorModelType]):
+class SingleQubitError(ErrorOperation[ErrorModelType], frozen=True):
     """SingleQubitError operation.
 
     Fields:

--- a/src/bloqade/squin/analysis/nsites/analysis.py
+++ b/src/bloqade/squin/analysis/nsites/analysis.py
@@ -23,11 +23,11 @@ class NSitesAnalysis(Forward[Sites]):
         if method is not None:
             return method(self, frame, stmt)
         elif stmt.has_trait(HasSites):
-            has_sites_trait = stmt.get_trait(HasSites)
+            has_sites_trait = stmt.get_present_trait(HasSites)
             sites = has_sites_trait.get_sites(stmt)
             return (NumberSites(sites=sites),)
         elif stmt.has_trait(FixedSites):
-            sites_trait = stmt.get_trait(FixedSites)
+            sites_trait = stmt.get_present_trait(FixedSites)
             return (NumberSites(sites=sites_trait.data),)
         else:
             return (NoSites(),)

--- a/src/bloqade/visual/animation/base.py
+++ b/src/bloqade/visual/animation/base.py
@@ -45,10 +45,12 @@ class GateArtist:
 class GlobalGateArtist(GateArtist):
     mpl_obj: mpatches.Rectangle
 
-    def __init__(self, mpl_ax: Any, xmin, ymin, width, height, color):
+    def __init__(
+        self, mpl_ax: Any, xmin: float, ymin: float, width: float, height: float, color
+    ):
         super().__init__(mpl_ax)
         rc = mpatches.Rectangle(
-            [xmin, ymin], width, height, color=color, alpha=0.6, visible=False
+            (xmin, ymin), width, height, color=color, alpha=0.6, visible=False
         )
         mpl_ax.add_patch(rc)
         self.mpl_obj = rc
@@ -56,7 +58,7 @@ class GlobalGateArtist(GateArtist):
     def clear_data(self) -> None:
         self.mpl_obj.set_width(0)
         self.mpl_obj.set_height(0)
-        self.mpl_obj.set_xy([0, 0])
+        self.mpl_obj.set_xy((0, 0))
 
     def get_artists(self) -> Tuple[Any]:
         return (self.mpl_obj,)
@@ -86,7 +88,7 @@ class RowRegionGateArtist(GateArtist):
         self.width = width
         self.xmin = xmin
         rc_btm = mpatches.Rectangle(
-            [xmin, ymin_keepout],
+            (xmin, ymin_keepout),
             width,
             ymin - ymin_keepout,
             color=color,
@@ -97,13 +99,13 @@ class RowRegionGateArtist(GateArtist):
         self.mpl_obj_keepout_btm = rc_btm
 
         rc = mpatches.Rectangle(
-            [xmin, ymin], width, ymax - ymin, color=color, alpha=0.6, visible=False
+            (xmin, ymin), width, ymax - ymin, color=color, alpha=0.6, visible=False
         )
         mpl_ax.add_patch(rc)
         self.mpl_obj = rc
 
         rc_top = mpatches.Rectangle(
-            [xmin, ymax],
+            (xmin, ymax),
             width,
             ymax_keepout - ymax,
             color=color,
@@ -116,31 +118,31 @@ class RowRegionGateArtist(GateArtist):
     def clear_data(self) -> None:
         self.mpl_obj.set_width(0)
         self.mpl_obj.set_height(0)
-        self.mpl_obj.set_xy([0, 0])
+        self.mpl_obj.set_xy((0, 0))
 
         self.mpl_obj_keepout_top.set_width(0)
         self.mpl_obj_keepout_top.set_height(0)
-        self.mpl_obj_keepout_top.set_xy([0, 0])
+        self.mpl_obj_keepout_top.set_xy((0, 0))
 
         self.mpl_obj_keepout_btm.set_width(0)
         self.mpl_obj_keepout_btm.set_height(0)
-        self.mpl_obj_keepout_btm.set_xy([0, 0])
+        self.mpl_obj_keepout_btm.set_xy((0, 0))
 
-    def get_artists(self) -> Tuple[Any]:
+    def get_artists(self) -> Tuple[Any, ...]:
         return (self.mpl_obj, self.mpl_obj_keepout_top, self.mpl_obj_keepout_btm)
 
     def update_data(self, ymin, ymax, ymin_keepout, ymax_keepout):
         self.mpl_obj.set_height(ymax - ymin)
         self.mpl_obj.set_width(self.width)
-        self.mpl_obj.set_xy([self.xmin, ymin])
+        self.mpl_obj.set_xy((self.xmin, ymin))
 
         self.mpl_obj_keepout_top.set_height(ymax_keepout - ymax)
         self.mpl_obj_keepout_top.set_width(self.width)
-        self.mpl_obj_keepout_top.set_xy([self.xmin, ymax])
+        self.mpl_obj_keepout_top.set_xy((self.xmin, ymax))
 
         self.mpl_obj_keepout_btm.set_height(ymin - ymin_keepout)
         self.mpl_obj_keepout_btm.set_width(self.width)
-        self.mpl_obj_keepout_btm.set_xy([self.xmin, ymin_keepout])
+        self.mpl_obj_keepout_btm.set_xy((self.xmin, ymin_keepout))
 
     def set_visible(self, visible: bool):
         self.mpl_obj.set_visible(visible)
@@ -194,11 +196,19 @@ class FieldOfView:
         )
 
     @property
-    def width(self):
+    def width(self) -> float:
+        if self.xmax is None or self.xmin is None:
+            raise ValueError(
+                "Can't return width of FOV as either xmin or xmax are undefined"
+            )
         return self.xmax - self.xmin
 
     @property
-    def height(self):
+    def height(self) -> float:
+        if self.ymax is None or self.ymin is None:
+            raise ValueError(
+                "Can't return width of FOV as either ymin or ymax are undefined"
+            )
         return self.ymax - self.ymin
 
     def to_json(self):


### PR DESCRIPTION
Got it down to 14 errors (starting out with 69). Not sure if all changes make sense.

The errors that are left are mostly ones such as this:

```python
kirin-workspace/bloqade-circuit/src/bloqade/stim/emit/stim.py:35:9 - error: Method "emit_block" overrides class "EmitABC" in an incompatible manner
    Return type mismatch: base method returns type "str", override returns type "str | None"
      Type "str | None" is not assignable to type "str"
        "None" is not assignable to "str" (reportIncompatibleMethodOverride)
```

I'm not sure what the best way to deal with those method overrides is.

Also, there's still a bunch of errors in `visual/animation`, which I could fix, but it would require some type assertions here and there (i.e. actually raising an error if the type expectation is not met) and I didn't want to go and break @kaihsin animation scripts.

We can discuss & continue here, or just merge (if the changes are fine) and continue in a separate PR, since this already improves things a bit.