### PR TITLE
Removing `form_m` from pyqrack interpreter. 

### DIFF
--- a/src/bloqade/pyqrack/noise/native.py
+++ b/src/bloqade/pyqrack/noise/native.py
@@ -93,7 +93,7 @@ class PyQrackMethods(interp.MethodTable):
 
         for qarg in active_qubits:
             if interp.rng_state.uniform() <= stmt.prob:
-                qarg.ref.sim_reg.r(qarg.addr)
+                qarg.ref.sim_reg.m(qarg.addr)
                 qarg.drop()
 
         return ()

--- a/src/bloqade/pyqrack/noise/native.py
+++ b/src/bloqade/pyqrack/noise/native.py
@@ -93,8 +93,7 @@ class PyQrackMethods(interp.MethodTable):
 
         for qarg in active_qubits:
             if interp.rng_state.uniform() <= stmt.prob:
-                sim_reg = qarg.ref.sim_reg
-                sim_reg.force_m(qarg.addr, 0)
+                qarg.ref.sim_reg.r(qarg.addr)
                 qarg.drop()
 
         return ()

--- a/test/pyqrack/runtime/noise/native/test_pauli.py
+++ b/test/pyqrack/runtime/noise/native/test_pauli.py
@@ -79,7 +79,7 @@ def test_cz_pauli_channel_false():
     rng_state.choice.side_effect = ["y"]
     rng_state.uniform.return_value = 0.5
     sim_reg = run_mock(test_atom_loss, rng_state)
-    sim_reg.assert_has_calls([call.mcz([0], 1), call.force_m(0, 0), call.y(1)])
+    sim_reg.assert_has_calls([call.mcz([0], 1), call.m(0), call.y(1)])
 
 
 def test_cz_pauli_channel_true():

--- a/test/pyqrack/runtime/test_dyn_memory.py
+++ b/test/pyqrack/runtime/test_dyn_memory.py
@@ -25,7 +25,7 @@ def test():
         dynamic_qubits=True,
     )
 
-    N = 50
+    N = 20
 
     result = target.multi_run(ghz, 100, N)
     result = Counter("".join(str(int(bit)) for bit in bits) for bits in result)


### PR DESCRIPTION
should close #169 caused by the simulator getting to a weird state where the probability of measuring |0> becomes probability 0.0 causing the interpreter to crash when an atom is lost during noise simulations. We keep track of the atom state