### PR TITLE
New Squin statements. 

### DIFF
--- a/src/bloqade/squin/op/stmts.py
+++ b/src/bloqade/squin/op/stmts.py
@@ -22,17 +22,6 @@ class CompositeOp(Operator):
     pass
 
 
-@statement(dialect=dialect)
-class Broadcast(CompositeOp):
-    """This takes an operator and allows it to be applied to a list of qubits."""
-
-    traits = frozenset(
-        {ir.Pure(), lowering.FromPythonCall(), MaybeUnitary(), HasSites()}
-    )
-    is_unitary: bool = info.attribute(default=False)
-    op: ir.SSAValue = info.argument(OpType)
-
-
 @statement
 class BinaryOp(CompositeOp):
     lhs: ir.SSAValue = info.argument(OpType)

--- a/src/bloqade/squin/op/stmts.py
+++ b/src/bloqade/squin/op/stmts.py
@@ -22,6 +22,15 @@ class CompositeOp(Operator):
     pass
 
 
+@statement(dialect=dialect)
+class Broadcast(CompositeOp):
+    traits = frozenset(
+        {ir.Pure(), lowering.FromPythonCall(), MaybeUnitary(), HasSites()}
+    )
+    is_unitary: bool = info.attribute(default=False)
+    op: ir.SSAValue = info.argument(OpType)
+
+
 @statement
 class BinaryOp(CompositeOp):
     lhs: ir.SSAValue = info.argument(OpType)

--- a/src/bloqade/squin/op/stmts.py
+++ b/src/bloqade/squin/op/stmts.py
@@ -114,6 +114,14 @@ class ConstantUnitary(ConstantOp):
     )
 
 
+class U3(PrimitiveOp):
+    traits = frozenset({ir.Pure(), lowering.FromPythonCall(), Unitary(), FixedSites(1)})
+    theta: ir.SSAValue = info.argument(types.Float)
+    phi: ir.SSAValue = info.argument(types.Float)
+    lam: ir.SSAValue = info.argument(types.Float)
+    result: ir.ResultValue = info.result(OpType)
+
+
 @statement(dialect=dialect)
 class PhaseOp(PrimitiveOp):
     """
@@ -147,6 +155,16 @@ class ShiftOp(PrimitiveOp):
 @statement
 class PauliOp(ConstantUnitary):
     pass
+
+
+@statement(dialect=dialect)
+class CliffordString(ConstantUnitary):
+    traits = frozenset({ir.Pure(), lowering.FromPythonCall(), Unitary(), HasSites()})
+    string: str = info.attribute()
+
+    def verify(self) -> None:
+        # TODO: implement verification of the Clifford string
+        pass
 
 
 @statement(dialect=dialect)

--- a/src/bloqade/squin/op/stmts.py
+++ b/src/bloqade/squin/op/stmts.py
@@ -152,8 +152,10 @@ class CliffordString(ConstantUnitary):
     string: str = info.attribute()
 
     def verify(self) -> None:
-        # TODO: implement verification of the Clifford string
-        pass
+        if not set("XYZHS").issuperset(self.string):
+            raise ValueError(
+                f"Invalid Clifford string: {self.string}. Must be a combination of 'X', 'Y', 'Z', 'H', and 'S'."
+            )
 
 
 @statement(dialect=dialect)

--- a/src/bloqade/squin/op/stmts.py
+++ b/src/bloqade/squin/op/stmts.py
@@ -24,6 +24,8 @@ class CompositeOp(Operator):
 
 @statement(dialect=dialect)
 class Broadcast(CompositeOp):
+    """This takes an operator and allows it to be applied to a list of qubits."""
+
     traits = frozenset(
         {ir.Pure(), lowering.FromPythonCall(), MaybeUnitary(), HasSites()}
     )

--- a/src/bloqade/squin/qubit.py
+++ b/src/bloqade/squin/qubit.py
@@ -35,6 +35,13 @@ class Apply(ir.Statement):
 
 
 @statement(dialect=dialect)
+class Broadcast(ir.Statement):
+    traits = frozenset({lowering.FromPythonCall()})
+    operator: ir.SSAValue = info.argument(OpType)
+    qubits: ir.SSAValue = info.argument(ilist.IListType[QubitType])
+
+
+@statement(dialect=dialect)
 class Measure(ir.Statement):
     traits = frozenset({lowering.FromPythonCall()})
     qubits: ir.SSAValue = info.argument(ilist.IListType[QubitType])


### PR DESCRIPTION
This PR is addressing the new squin statements. However, after discussion with @kaihsin and @Roger-luo we have slightly modified the semantics to make things a bit cleaner:

1. `Boradcast` is now an appliy-like statement, see #206 
2.  `PualiString` is now `CliffordString` to enable better rewrites to STIM. 
