### PR TITLE
Add pyqrack extas with platform dependent constraints. 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,11 +38,8 @@ cirq = [
     "cirq-core>=1.4.1",
     "cirq-core[contrib]>=1.4.1",
 ]
-pyqrack-cpu = [
-
-]
-pyqrack = [
-    "pyqrack>=1.38.2",
+pyqrack-opencl = [
+    "pyqrack>=1.38.2 ; sys_platform != 'darwin'",
 ]
 pyqrack-cuda = [
     "pyqrack-cuda>=1.38.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,8 @@ dependencies = [
     "rich>=13.9.4",
     "pydantic>=1.3.0,<2.11.0",
     "pandas>=2.2.3",
+    "pyqrack>=1.38.2 ; sys_platform == 'darwin'",
+    "pyqrack-cpu>=1.38.2 ; sys_platform != 'darwin'",
 ]
 
 [project.optional-dependencies]
@@ -37,8 +39,7 @@ cirq = [
     "cirq-core[contrib]>=1.4.1",
 ]
 pyqrack-cpu = [
-    "pyqrack>=1.38.2 ; sys_platform == 'darwin'",
-    "pyqrack-cpu>=1.38.2 ; sys_platform != 'darwin'",
+
 ]
 pyqrack = [
     "pyqrack>=1.38.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,16 @@ cirq = [
     "cirq-core>=1.4.1",
     "cirq-core[contrib]>=1.4.1",
 ]
+pyqrack-cpu = [
+    "pyqrack>=1.38.2 ; sys_platform == 'darwin'",
+    "pyqrack-cpu>=1.38.2 ; sys_platform != 'darwin'",
+]
+pyqrack = [
+    "pyqrack>=1.38.2",
+]
+pyqrack-cuda = [
+    "pyqrack-cuda>=1.38.2",
+]
 
 [build-system]
 requires = ["hatchling"]


### PR DESCRIPTION
I am also making pyqrack-cpu implementation a default dependency since it has no other dependencies it is pretty light