### PR TITLE
Fixing bugs related to kirin 0.17.3 version. 

### DIFF
--- a/src/bloqade/qasm2/passes/noise.py
+++ b/src/bloqade/qasm2/passes/noise.py
@@ -38,7 +38,6 @@ class NoisePass(Pass):
 
     def unsafe_run(self, mt: ir.Method):
         result = Walk(InsertGetQubit()).rewrite(mt.code)
-        mt.print()
         HintConst(self.dialects).unsafe_run(mt)
         frame, _ = self.address_analysis.run_analysis(mt, no_raise=self.no_raise)
         result = (

--- a/src/bloqade/qasm2/passes/noise.py
+++ b/src/bloqade/qasm2/passes/noise.py
@@ -1,7 +1,7 @@
 from dataclasses import field, dataclass
 
 from kirin import ir
-from kirin.passes import Pass
+from kirin.passes import Pass, HintConst
 from kirin.rewrite import (
     Walk,
     Chain,
@@ -10,11 +10,10 @@ from kirin.rewrite import (
     DeadCodeElimination,
     CommonSubexpressionElimination,
 )
-from kirin.rewrite.abc import RewriteResult
 
 from bloqade.noise import native
 from bloqade.analysis import address
-from bloqade.qasm2.rewrite.heuristic_noise import NoiseRewriteRule
+from bloqade.qasm2.rewrite.heuristic_noise import InsertGetQubit, NoiseRewriteRule
 
 
 @dataclass
@@ -38,16 +37,18 @@ class NoisePass(Pass):
         self.address_analysis = address.AddressAnalysis(self.dialects)
 
     def unsafe_run(self, mt: ir.Method):
-        result = RewriteResult()
-
-        frame, res = self.address_analysis.run_analysis(mt, no_raise=False)
+        result = Walk(InsertGetQubit()).rewrite(mt.code)
+        mt.print()
+        HintConst(self.dialects).unsafe_run(mt)
+        frame, _ = self.address_analysis.run_analysis(mt, no_raise=self.no_raise)
         result = (
             Walk(
                 NoiseRewriteRule(
                     address_analysis=frame.entries,
                     noise_model=self.noise_model,
                     gate_noise_params=self.gate_noise_params,
-                )
+                ),
+                reverse=True,
             )
             .rewrite(mt.code)
             .join(result)

--- a/src/bloqade/qasm2/rewrite/uop_to_parallel.py
+++ b/src/bloqade/qasm2/rewrite/uop_to_parallel.py
@@ -58,10 +58,6 @@ class SimpleMergePolicy(MergePolicyABC):
     group_has_merged: Dict[int, bool] = field(default_factory=dict)
     """Mapping from group number to whether the group has been merged"""
 
-    def __post_init__(self):
-        for group_number in range(len(self.merge_groups)):
-            self.group_has_merged[group_number] = False
-
     @staticmethod
     def same_id_checker(ssa1: ir.SSAValue, ssa2: ir.SSAValue):
         if ssa1 is ssa2:

--- a/src/bloqade/qasm2/rewrite/uop_to_parallel.py
+++ b/src/bloqade/qasm2/rewrite/uop_to_parallel.py
@@ -58,6 +58,10 @@ class SimpleMergePolicy(MergePolicyABC):
     group_has_merged: Dict[int, bool] = field(default_factory=dict)
     """Mapping from group number to whether the group has been merged"""
 
+    def __post_init__(self):
+        for group_number in range(len(self.merge_groups)):
+            self.group_has_merged[group_number] = False
+
     @staticmethod
     def same_id_checker(ssa1: ir.SSAValue, ssa2: ir.SSAValue):
         if ssa1 is ssa2:
@@ -154,7 +158,7 @@ class SimpleMergePolicy(MergePolicyABC):
             self.group_has_merged[group_number] = result.has_done_something
             return result
 
-        if self.group_has_merged[group_number]:
+        if self.group_has_merged.setdefault(group_number, False):
             node.delete()
 
         return RewriteResult(has_done_something=self.group_has_merged[group_number])


### PR DESCRIPTION
fixes:

* ParallelToUop I just added a `setdefault` so that it would register the dictionary value and then overwrite it later
* For RewriteNoiseModel: I split up the rewrites to be correct when having the new traversal order. 