### PR TITLE
Fixing bug with wrong enum value

### DIFF
--- a/src/bloqade/pyqrack/qasm2/uop.py
+++ b/src/bloqade/pyqrack/qasm2/uop.py
@@ -2,6 +2,7 @@ import math
 
 from kirin import interp
 
+from pyqrack.pauli import Pauli
 from bloqade.pyqrack.reg import PyQrackQubit
 from bloqade.qasm2.dialects import uop
 
@@ -26,7 +27,14 @@ class PyQrackMethods(interp.MethodTable):
         "tdg": "adjt",
     }
 
-    AXIS_MAP = {"rx": 1, "ry": 2, "rz": 3, "crx": 1, "cry": 2, "crz": 3}
+    AXIS_MAP = {
+        "rx": Pauli.PauliX,
+        "ry": Pauli.PauliY,
+        "rz": Pauli.PauliZ,
+        "crx": Pauli.PauliX,
+        "cry": Pauli.PauliY,
+        "crz": Pauli.PauliZ,
+    }
 
     @interp.impl(uop.Barrier)
     def barrier(

--- a/test/pyqrack/runtime/test_qrack.py
+++ b/test/pyqrack/runtime/test_qrack.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock, call
 from kirin import ir
 
 from bloqade import qasm2
+from pyqrack.pauli import Pauli
 from bloqade.pyqrack.base import MockMemory, PyQrackInterpreter
 
 
@@ -63,9 +64,9 @@ def test_rotation_gates():
 
     sim_reg.assert_has_calls(
         [
-            call.r(1, 0.5, 0),
-            call.r(2, 0.5, 1),
-            call.r(3, 0.5, 2),
+            call.r(Pauli.PauliX, 0.5, 0),
+            call.r(Pauli.PauliY, 0.5, 1),
+            call.r(Pauli.PauliZ, 0.5, 2),
         ]
     )
 
@@ -130,7 +131,7 @@ def test_special_control():
     sim_reg = run_mock(program)
     sim_reg.assert_has_calls(
         [
-            call.mcr(1, 0.5, [0], 1),
+            call.mcr(Pauli.PauliX, 0.5, [0], 1),
             call.mcu([1], 2, 0, 0, 0.5),
             call.mcu([2], 0, 0.5, 0.2, 0.1),
             call.mcx([0, 1], 2),


### PR DESCRIPTION
Note if you look at the definition of the Pauli enum https://github.com/unitaryfoundation/pyqrack/blob/819c58aed5a5695ee0a21f6274575b55deecb791/pyqrack/pauli.py#L17 y -> 3 and z -> 2 which is pretty weird lol. 

cc: @david-pl 