### PR TITLE
Fixing test to match statement traversal order

### DIFF
--- a/test/qasm2/passes/test_heuristic_noise.py
+++ b/test/qasm2/passes/test_heuristic_noise.py
@@ -287,11 +287,11 @@ def test_global_noise():
     expected_block = ir.Block(
         [
             n_qubits := constant.Constant(1),
-            reg0 := core.QRegNew(n_qubits.result),
-            zero := constant.Constant(0),
-            q0 := core.QRegGet(reg0.result, zero.result),
             reg1 := core.QRegNew(n_qubits.result),
+            zero := constant.Constant(0),
             q1 := core.QRegGet(reg1.result, zero.result),
+            reg0 := core.QRegNew(n_qubits.result),
+            q0 := core.QRegGet(reg0.result, zero.result),
             reg_list := ilist.New(
                 values=[reg0.result, reg1.result], elem_type=reg0.result.type
             ),


### PR DESCRIPTION
In the new kirin patch the traversal order of the statements during a `Walk` rewrite pass has changed again so I have fixed the test to match the traversal order of `Walk`. 