### PR TITLE
Fix default arguments for PyQrack. 

### DIFF
--- a/src/bloqade/pyqrack/base.py
+++ b/src/bloqade/pyqrack/base.py
@@ -26,6 +26,21 @@ class PyQrackOptions(typing.TypedDict):
     isOpenCL: bool
 
 
+def _validate_pyqrack_options(options: PyQrackOptions) -> None:
+    if options["isBinaryDecisionTree"] and options["isStabilizerHybrid"]:
+        raise ValueError(
+            "Cannot use both isBinaryDecisionTree and isStabilizerHybrid at the same time."
+        )
+    elif options["isTensorNetwork"] and options["isBinaryDecisionTree"]:
+        raise ValueError(
+            "Cannot use both isTensorNetwork and isBinaryDecisionTree at the same time."
+        )
+    elif options["isTensorNetwork"] and options["isStabilizerHybrid"]:
+        raise ValueError(
+            "Cannot use both isTensorNetwork and isStabilizerHybrid at the same time."
+        )
+
+
 def _default_pyqrack_args() -> PyQrackOptions:
     return PyQrackOptions(
         qubitCount=-1,
@@ -44,6 +59,9 @@ def _default_pyqrack_args() -> PyQrackOptions:
 class MemoryABC(abc.ABC):
     pyqrack_options: PyQrackOptions = field(default_factory=_default_pyqrack_args)
     sim_reg: "QrackSimulator" = field(init=False)
+
+    def __post_init__(self):
+        _validate_pyqrack_options(self.pyqrack_options)
 
     @abc.abstractmethod
     def allocate(self, n_qubits: int) -> tuple[int, ...]:

--- a/src/bloqade/pyqrack/base.py
+++ b/src/bloqade/pyqrack/base.py
@@ -32,7 +32,7 @@ def _default_pyqrack_args() -> PyQrackOptions:
         isTensorNetwork=False,
         isSchmidtDecomposeMulti=True,
         isSchmidtDecompose=True,
-        isStabilizerHybrid=True,
+        isStabilizerHybrid=False,
         isBinaryDecisionTree=True,
         isPaged=True,
         isCpuGpuHybrid=True,

--- a/test/pyqrack/test_target.py
+++ b/test/pyqrack/test_target.py
@@ -103,7 +103,9 @@ def test_target_glob():
 
         return q1
 
-    target = PyQrack(6)
+    target = PyQrack(
+        6, pyqrack_options={"isBinaryDecisionTree": False, "isStabilizerHybrid": True}
+    )
     q1 = target.run(multiple_registers)
 
     assert isinstance(q1, ilist.IList)


### PR DESCRIPTION
I'm gonna open an issue on PyQrack repo about this it would be good to know what are good flags to pass into the `QrackSimulator` object. Currently, some configurations of options will cause a runtime error when executing the simulation instead of a value error when constructing the object. I'll add validation on the arguments passed into the `QrackSimulator` object as we slowly figure out the bad behavior. 