### PR TITLE
Change Clifford String to Pauli String

### DIFF
--- a/src/bloqade/squin/op/stmts.py
+++ b/src/bloqade/squin/op/stmts.py
@@ -147,14 +147,14 @@ class PauliOp(ConstantUnitary):
 
 
 @statement(dialect=dialect)
-class CliffordString(ConstantUnitary):
+class PauliString(ConstantUnitary):
     traits = frozenset({ir.Pure(), lowering.FromPythonCall(), Unitary(), HasSites()})
     string: str = info.attribute()
 
     def verify(self) -> None:
-        if not set("XYZHS").issuperset(self.string):
+        if not set("XYZ").issuperset(self.string):
             raise ValueError(
-                f"Invalid Clifford string: {self.string}. Must be a combination of 'X', 'Y', 'Z', 'H', and 'S'."
+                f"Invalid Pauli string: {self.string}. Must be a combination of 'X', 'Y', and 'Z'."
             )
 
 


### PR DESCRIPTION
Per yesterday's meeting Scientific Software meeting agreement, the Clifford string operator should be restricted to just Pauli's. 

@weinbe58 @Roger-luo I know there were several methods mentioned to translating the string into an actual `OpType` that can be used in other statements, ranging from lowering, canonicalization rewrite, etc. What is the _exact_ approach that should be taken for this? I'd like to open an issue to keep track of the infrastructure required for this.

cc: @cduck @kaihsin 