### PR TITLE
remove custom constprop for wire

### DIFF
--- a/src/bloqade/squin/wire.py
+++ b/src/bloqade/squin/wire.py
@@ -6,7 +6,7 @@ circuits. Thus we do not define wrapping functions for the statements in this
 dialect.
 """
 
-from kirin import ir, types, interp, lowering
+from kirin import ir, types, lowering
 from kirin.decl import info, statement
 from kirin.lowering import wraps
 
@@ -110,18 +110,6 @@ class MeasureAndReset(ir.Statement):
 class Reset(ir.Statement):
     traits = frozenset({lowering.FromPythonCall(), WireTerminator()})
     wire: ir.SSAValue = info.argument(WireType)
-
-
-# Issue where constant propagation can't handle
-# multiple return values from Apply properly
-@dialect.register(key="constprop")
-class ConstPropWire(interp.MethodTable):
-
-    @interp.impl(Apply)
-    @interp.impl(Broadcast)
-    def apply(self, interp, frame, stmt: Apply):
-
-        return frame.get_values(stmt.inputs)
 
 
 @wraps(Unwrap)

--- a/test/squin/test_constprop.py
+++ b/test/squin/test_constprop.py
@@ -1,9 +1,8 @@
-# There's a method table in the wire dialect statements
-# that handles the multiple return values from Apply and Broadcast
-# that can cause problems for constant propoagation's default implementation.
-# These tests just make sure there are corresponding lattice types per each
-# SSA value (as opposed to a bunch of "missing" entries despite multiple
-# return values from Broadcast and Apply)
+# These tests are used to verify the multiple
+# result values from certain statements are handled properly
+# in constant propagation. Originally a custom constprop
+# method table had to be implemented but the newer version of
+# Kirin has fixed this issue (:
 
 from kirin import ir, types
 from kirin.passes import Fold


### PR DESCRIPTION
@Roger-luo has fixed Kirin's constprop to [handle multiple result values](https://github.com/QuEraComputing/kirin/pull/393) (:  the custom constprop for certain wire statements is no longer needed

