### PR TITLE
simplify loads

### DIFF
--- a/src/bloqade/qasm2/__init__.py
+++ b/src/bloqade/qasm2/__init__.py
@@ -17,3 +17,4 @@ from .types import (
 )
 from .groups import gate as gate, main as main, extended as extended
 from ._wrappers import *  # noqa: F403
+from ._qasm_loading import loads as loads, loadfile as loadfile

--- a/src/bloqade/qasm2/_qasm_loading.py
+++ b/src/bloqade/qasm2/_qasm_loading.py
@@ -1,0 +1,83 @@
+from typing import Any
+
+from kirin import ir
+
+from .groups import main
+from .parse.lowering import QASM2
+
+
+def loads(
+    qasm: str,
+    *,
+    kernel_name: str = "main",
+    dialects: ir.DialectGroup | None = None,
+    globals: dict[str, Any] | None = None,
+    file: str | None = None,
+    lineno_offset: int = 0,
+    col_offset: int = 0,
+    compactify: bool = True,
+) -> ir.Method[[], None]:
+    """Loads a QASM2 string and returns the corresponding kernel object.
+
+    Args:
+        qasm (str): The QASM2 string to load.
+
+    Keyword Args:
+        kernel_name (str): The name of the kernel to load. Defaults to "main".
+        dialects (ir.DialectGroup | None): The dialects to use. Defaults to `qasm2.main`.
+        returns (str | None): The return type of the kernel. Defaults to None.
+        globals (dict[str, Any] | None): The global variables to use. Defaults to None.
+        file (str | None): The file name for error reporting. Defaults to None.
+        lineno_offset (int): The line number offset for error reporting. Defaults to 0.
+        col_offset (int): The column number offset for error reporting. Defaults to 0.
+        compactify (bool): Whether to compactify the output. Defaults to True.
+    """
+    return QASM2(dialects or main).loads(
+        qasm,
+        kernel_name=kernel_name,
+        globals=globals,
+        file=file,
+        lineno_offset=lineno_offset,
+        col_offset=col_offset,
+        compactify=compactify,
+    )
+
+
+def loadfile(
+    qasm_file: str,
+    *,
+    kernel_name: str = "main",
+    dialects: ir.DialectGroup | None = None,
+    globals: dict[str, Any] | None = None,
+    file: str | None = None,
+    lineno_offset: int = 0,
+    col_offset: int = 0,
+    compactify: bool = True,
+) -> ir.Method[[], None]:
+    """Loads a QASM2 file and returns the corresponding kernel object.
+
+    Args:
+        qasm_file (str): The QASM2 file to load.
+
+    Keyword Args:
+        kernel_name (str): The name of the kernel to load. Defaults to "main".
+        dialects (ir.DialectGroup | None): The dialects to use. Defaults to `qasm2.main`.
+        returns (str | None): The return type of the kernel. Defaults to None.
+        globals (dict[str, Any] | None): The global variables to use. Defaults to None.
+        file (str | None): The file name for error reporting. Defaults to None.
+        lineno_offset (int): The line number offset for error reporting. Defaults to 0.
+        col_offset (int): The column number offset for error reporting. Defaults to 0.
+        compactify (bool): Whether to compactify the output. Defaults to True.
+    """
+    with open(qasm_file, "r") as f:
+        qasm = f.read()
+    return loads(
+        qasm,
+        kernel_name=kernel_name,
+        dialects=dialects,
+        globals=globals,
+        file=file,
+        lineno_offset=lineno_offset,
+        col_offset=col_offset,
+        compactify=compactify,
+    )

--- a/src/bloqade/qasm2/_qasm_loading.py
+++ b/src/bloqade/qasm2/_qasm_loading.py
@@ -31,6 +31,20 @@ def loads(
         lineno_offset (int): The line number offset for error reporting. Defaults to 0.
         col_offset (int): The column number offset for error reporting. Defaults to 0.
         compactify (bool): Whether to compactify the output. Defaults to True.
+
+    Example:
+
+    ```python
+    from bloqade import qasm2
+    method = qasm2.loads('''
+    OPENQASM 2.0;
+    qreg q[2];
+    creg c[2];
+    h q[0];
+    cx q[0], q[1];
+    measure q[0] -> c[0];
+    ''')
+    ```
     """
     return QASM2(dialects or main).loads(
         qasm,
@@ -54,7 +68,7 @@ def loadfile(
     col_offset: int = 0,
     compactify: bool = True,
 ) -> ir.Method[[], None]:
-    """Loads a QASM2 file and returns the corresponding kernel object.
+    """Loads a QASM2 file and returns the corresponding kernel object. See also `loads`.
 
     Args:
         qasm_file (str): The QASM2 file to load.


### PR DESCRIPTION
address #238 one question tho, was there a particular reason why the `loads` and `loadfile` was living inside the lowering target? @weinbe58 I think if not would be nice to move them out. This is not an object we expect users to use directly cuz it would be too confusing without knowing about lowering process.