### PR TITLE
Fix lowering missing return

### DIFF
--- a/src/bloqade/qasm2/_qasm_loading.py
+++ b/src/bloqade/qasm2/_qasm_loading.py
@@ -9,6 +9,7 @@ from .parse.lowering import QASM2
 def loads(
     qasm: str,
     *,
+    returns: str | None = None,
     kernel_name: str = "main",
     dialects: ir.DialectGroup | None = None,
     globals: dict[str, Any] | None = None,
@@ -54,6 +55,7 @@ def loads(
         lineno_offset=lineno_offset,
         col_offset=col_offset,
         compactify=compactify,
+        returns=returns,
     )
 
 
@@ -61,6 +63,7 @@ def loadfile(
     qasm_file: str,
     *,
     kernel_name: str = "main",
+    returns: str | None = None,
     dialects: ir.DialectGroup | None = None,
     globals: dict[str, Any] | None = None,
     file: str | None = None,
@@ -94,4 +97,5 @@ def loadfile(
         lineno_offset=lineno_offset,
         col_offset=col_offset,
         compactify=compactify,
+        returns=returns,
     )

--- a/src/bloqade/qasm2/_qasm_loading.py
+++ b/src/bloqade/qasm2/_qasm_loading.py
@@ -9,8 +9,8 @@ from .parse.lowering import QASM2
 def loads(
     qasm: str,
     *,
-    returns: str | None = None,
     kernel_name: str = "main",
+    returns: str | None = None,
     dialects: ir.DialectGroup | None = None,
     globals: dict[str, Any] | None = None,
     file: str | None = None,
@@ -25,6 +25,7 @@ def loads(
 
     Keyword Args:
         kernel_name (str): The name of the kernel to load. Defaults to "main".
+        returns: (str | None): The return value of the kernel. Defaults to None.
         dialects (ir.DialectGroup | None): The dialects to use. Defaults to `qasm2.main`.
         returns (str | None): The return type of the kernel. Defaults to None.
         globals (dict[str, Any] | None): The global variables to use. Defaults to None.
@@ -78,6 +79,7 @@ def loadfile(
 
     Keyword Args:
         kernel_name (str): The name of the kernel to load. Defaults to "main".
+        returns: (str | None): The return value of the kernel. Defaults to None.
         dialects (ir.DialectGroup | None): The dialects to use. Defaults to `qasm2.main`.
         returns (str | None): The return type of the kernel. Defaults to None.
         globals (dict[str, Any] | None): The global variables to use. Defaults to None.

--- a/src/bloqade/qasm2/parse/lowering.py
+++ b/src/bloqade/qasm2/parse/lowering.py
@@ -55,7 +55,7 @@ class QASM2(lowering.LoweringABC[ast.Node]):
                     if return_value is None:
                         raise lowering.BuildError(f"Cannot find return value {returns}")
                 else:
-                    return_value = func.ConstantNone()
+                    frame.push(return_value := func.ConstantNone())
 
                 return_node = frame.push(func.Return(value_or_stmt=return_value))
 


### PR DESCRIPTION
I forgot to push the `None` statement to the frame when lowering from QASM2. 