### PR TITLE
Fixing Measure and fixing issues with the qregister types

### DIFF
--- a/src/bloqade/qasm2/_wrappers.py
+++ b/src/bloqade/qasm2/_wrappers.py
@@ -68,14 +68,20 @@ def measure(qreg: QReg, creg: CReg) -> None: ...
 def measure(qarg: Qubit, cbit: Bit) -> None: ...
 
 
-@wraps(core.Measure)
-def measure(qarg, cbit) -> None:
+@overload
+def measure(qarg: QReg, carg: Bit) -> None: ...
+@overload
+def measure(qarg: Qubit, carg: CReg) -> None: ...
+
+
+@wraps(core.MeasureAny)
+def measure(qarg, carg) -> None:
     """
     Measure the qubit `qarg` and store the result in the classical bit `cbit`.
 
     Args:
-        qarg: The qubit to measure.
-        cbit: The classical bit to store the result in.
+        qarg: The qubit/qregister to measure.
+        cbit: The classical bit/register to store the result in.
     """
     ...
 

--- a/src/bloqade/qasm2/dialects/core/_emit.py
+++ b/src/bloqade/qasm2/dialects/core/_emit.py
@@ -37,9 +37,13 @@ class Core(interp.MethodTable):
         frame.body.append(ast.Reset(qarg=qarg))
         return ()
 
-    @interp.impl(stmts.Measure)
+    @interp.impl(stmts.MeasureQubit)
+    @interp.impl(stmts.MeasureQReg)
     def emit_measure(
-        self, emit: EmitQASM2Main, frame: EmitQASM2Frame, stmt: stmts.Measure
+        self,
+        emit: EmitQASM2Main,
+        frame: EmitQASM2Frame,
+        stmt: stmts.MeasureQubit | stmts.MeasureQReg,
     ):
         qarg = emit.assert_node((ast.Bit, ast.Name), frame.get(stmt.qarg))
         carg = emit.assert_node((ast.Bit, ast.Name), frame.get(stmt.carg))

--- a/src/bloqade/qasm2/dialects/core/_typeinfer.py
+++ b/src/bloqade/qasm2/dialects/core/_typeinfer.py
@@ -1,14 +1,27 @@
 from kirin import types, interp
 from kirin.analysis import TypeInference
-from kirin.dialects import py
+from kirin.dialects import py, ilist
 
 from bloqade.qasm2.types import CRegType, QRegType, QubitType
 
+from .stmts import QRegNew
 from ._dialect import dialect
 
 
 @dialect.register(key="typeinfer")
 class TypeInfer(interp.MethodTable):
+
+    @interp.impl(QRegNew)
+    def range(
+        self,
+        interp_: TypeInference,
+        frame: interp.Frame[types.TypeAttribute],
+        stmt: QRegNew,
+    ):
+        n_qubits = interp_.maybe_const(stmt.n_qubits, int)
+        if n_qubits:
+            return (ilist.IListType[QubitType, types.Literal(n_qubits)],)
+        return (ilist.IListType[QubitType, types.Any],)
 
     @interp.impl(py.indexing.GetItem, QRegType, types.Int)
     def getitem_qreg(

--- a/src/bloqade/qasm2/groups.py
+++ b/src/bloqade/qasm2/groups.py
@@ -12,7 +12,7 @@ from bloqade.qasm2.dialects import (
     indexing,
     parallel,
 )
-from bloqade.qasm2.rewrite.desugar import IndexingDesugarPass
+from bloqade.qasm2.rewrite.desugar import QASMDesugarPass
 
 
 @ir.dialect_group([uop, func, expr, lowering.func, lowering.call])
@@ -97,7 +97,7 @@ def extended(self):
     fold_pass = passes.Fold(self)
     typeinfer_pass = passes.TypeInfer(self)
     ilist_desugar_pass = ilist.IListDesugar(self)
-    indexing_desugar_pass = IndexingDesugarPass(self)
+    qasm_desugar_pass = QASMDesugarPass(self)
 
     def run_pass(
         mt: ir.Method,
@@ -112,7 +112,7 @@ def extended(self):
         if typeinfer:
             typeinfer_pass(mt)
         ilist_desugar_pass(mt)
-        indexing_desugar_pass(mt)
+        qasm_desugar_pass(mt)
         if typeinfer:
             typeinfer_pass(mt)  # fix types after desugaring
             mt.verify_type()

--- a/src/bloqade/qasm2/passes/py2qasm.py
+++ b/src/bloqade/qasm2/passes/py2qasm.py
@@ -53,6 +53,12 @@ class _Py2QASM(RewriteRule):
             node.result.replace_by(node.value)
             node.delete()
             return RewriteResult(has_done_something=True)
+        elif isinstance(node, py.indexing.GetItem) and node.obj.type.is_subseteq(
+            core.QRegType
+        ):
+            node.replace_by(core.QRegGet(node.obj, node.index))
+            return RewriteResult(has_done_something=True)
+
         return RewriteResult()
 
 

--- a/src/bloqade/qasm2/passes/qasm2py.py
+++ b/src/bloqade/qasm2/passes/qasm2py.py
@@ -50,6 +50,9 @@ class _QASM2Py(RewriteRule):
         elif isinstance(node, expr.ConstPI):
             node.replace_by(py.Constant(value=pymath.pi))
             return RewriteResult(has_done_something=True)
+        elif isinstance(node, core.QRegGet):
+            node.replace_by(py.indexing.GetItem(obj=node.reg, index=node.idx))
+            return RewriteResult(has_done_something=True)
         else:
             return RewriteResult()
 

--- a/src/bloqade/qasm2/types.py
+++ b/src/bloqade/qasm2/types.py
@@ -1,3 +1,5 @@
+from typing import Any, TypeAlias
+
 from kirin import types
 from kirin.dialects import ilist
 
@@ -16,7 +18,7 @@ class Bit:
     pass
 
 
-QReg = ilist.IList[Qubit, types.Any]
+QReg: TypeAlias = ilist.IList[Qubit, Any]
 
 
 class CReg:
@@ -29,7 +31,8 @@ class CReg:
 BitType = types.PyClass(Bit)
 """Kirin type for a classical bit."""
 
-QRegType = ilist.IListType[QubitType, types.Any]
+N = types.TypeVar("N")
+QRegType = ilist.IListType[QubitType, N]
 """Kirin type for a quantum register."""
 
 CRegType = types.PyClass(CReg)


### PR DESCRIPTION
Trying to fix some major problems:

1. Type inference wasn't inferring the length of the qubit register, this should be fixed now
2. Switching to using a rewrite pass to implement the syntax sugar for measure
3. Adding some fixes to `Py2QASM` and `QASM2Py` since the register is now an IList
4. Adding `HintLen` to QASM2Fold pass in order to help unroll loops which depend on `len` of a register

I've notice a few bugs in the current passes. namely #255 but also I'm trying to figure out an issue with `scf.PickIfElse` unroll pass which seems to be deleting code. trying to come up with a MWE

cc: @Roger-luo 