### PR TITLE
Implement scf & invoke methods for fidelity analysis

### DIFF
--- a/src/bloqade/analysis/fidelity/__init__.py
+++ b/src/bloqade/analysis/fidelity/__init__.py
@@ -1,1 +1,2 @@
+from . import impls as impls
 from .analysis import FidelityAnalysis as FidelityAnalysis

--- a/src/bloqade/analysis/fidelity/analysis.py
+++ b/src/bloqade/analysis/fidelity/analysis.py
@@ -59,6 +59,8 @@ class FidelityAnalysis(Forward):
 
     addr_frame: ForwardFrame = field(init=False)
 
+    _run_post_succ_hook: bool = field(init=False, default=True)
+
     def initialize(self):
         super().initialize()
         self._current_gate_fidelity = 1.0
@@ -68,6 +70,9 @@ class FidelityAnalysis(Forward):
         return self
 
     def posthook_succ(self, frame: ForwardFrame, succ: Successor):
+        if not self._run_post_succ_hook:
+            return
+
         self.gate_fidelity *= self._current_gate_fidelity
         for i, _current_survival in enumerate(self._current_atom_survival_probability):
             self.atom_survival_probability[i] *= _current_survival

--- a/src/bloqade/analysis/fidelity/impls.py
+++ b/src/bloqade/analysis/fidelity/impls.py
@@ -1,0 +1,91 @@
+import numpy as np
+from kirin import interp
+from kirin.lattice import EmptyLattice
+from kirin.analysis import const
+from kirin.dialects import scf, func
+from kirin.dialects.scf.stmts import For, Yield, IfElse
+
+from .analysis import FidelityAnalysis
+
+
+@scf.dialect.register(key="circuit.fidelity")
+class ScfFidelityMethodTable(interp.MethodTable):
+
+    @interp.impl(IfElse)
+    def if_else(
+        self,
+        interp: FidelityAnalysis,
+        frame: interp.Frame[EmptyLattice],
+        stmt: IfElse,
+    ):
+        # NOTE: store current fidelity for later
+        current_gate_fidelity = interp._current_gate_fidelity
+        current_atom_survival = interp._current_atom_survival_probability
+
+        for s in stmt.then_body.stmts():
+            stmt_impl = interp.lookup_registry(frame=frame, stmt=s)
+            if stmt_impl is None:
+                continue
+
+            stmt_impl(interp=interp, frame=frame, stmt=s)
+
+        then_gate_fidelity = interp._current_gate_fidelity
+        then_atom_survival = interp._current_atom_survival_probability
+
+        # NOTE: reset fidelity of interp to check if the else body results in a worse fidelity
+        interp._current_gate_fidelity = current_gate_fidelity
+        interp._current_atom_survival_probability = current_atom_survival
+
+        for s in stmt.else_body.stmts():
+            stmt_impl = interp.lookup_registry(frame=frame, stmt=s)
+            if stmt_impl is None:
+                continue
+
+            stmt_impl(interp=interp, frame=frame, stmt=s)
+
+        else_gate_fidelity = interp._current_gate_fidelity
+        else_atom_survival = interp._current_atom_survival_probability
+
+        # NOTE: look for the "worse" branch
+        then_combined_fidelity = then_gate_fidelity * np.prod(then_atom_survival)
+        else_combined_fidelity = else_gate_fidelity * np.prod(else_atom_survival)
+
+        if then_combined_fidelity < else_combined_fidelity:
+            interp._current_gate_fidelity = then_gate_fidelity
+            interp._current_atom_survival_probability = then_atom_survival
+        else:
+            interp._current_gate_fidelity = else_gate_fidelity
+            interp._current_atom_survival_probability = else_atom_survival
+
+    @interp.impl(Yield)
+    def yield_(
+        self, interp: FidelityAnalysis, frame: interp.Frame[EmptyLattice], stmt: Yield
+    ):
+        # NOTE: yield can by definition only contain values, never any stmts, so fidelity cannot decrease
+        return
+
+    @interp.impl(For)
+    def for_loop(
+        self, interp: FidelityAnalysis, frame: interp.Frame[EmptyLattice], stmt: For
+    ):
+        if not isinstance(hint := stmt.iterable.hints.get("const"), const.Value):
+            # NOTE: not clear how long this loop is
+            # TODO: should we at least count the body once?
+            return
+
+        for _ in hint.data:
+            for s in stmt.body.stmts():
+                interp.eval_stmt(frame=frame, stmt=s)
+
+
+@func.dialect.register(key="circuit.fidelity")
+class FuncFidelityMethodTable(interp.MethodTable):
+    @interp.impl(func.Invoke)
+    def func_invoke(
+        self,
+        interp: FidelityAnalysis,
+        frame: interp.Frame[EmptyLattice],
+        stmt: func.Invoke,
+    ):
+        # TODO
+        pass

--- a/src/bloqade/analysis/fidelity/impls.py
+++ b/src/bloqade/analysis/fidelity/impls.py
@@ -88,6 +88,12 @@ class FuncFidelityMethodTable(interp.MethodTable):
         stmt: func.Invoke,
     ):
         mt = stmt.callee
+
+        # NOTE: we need to get the addresses of the nested kernel, so store for later
+        addr_frame = interp.addr_frame
+
+        # run the address analysis on the nested kernel
+        # TODO: this can't be right
         interp._run_address_analysis(mt, no_raise=False)
 
         # NOTE: run_method will also trigger the post_succ_hook, which we run afterwards anyways
@@ -97,3 +103,6 @@ class FuncFidelityMethodTable(interp.MethodTable):
         interp._run_post_succ_hook = False
         interp.run_method(method=stmt.callee, args=())
         interp._run_post_succ_hook = True
+
+        # Reset addr frame
+        interp.addr_frame = addr_frame

--- a/test/analysis/fidelity/test_fidelity.py
+++ b/test/analysis/fidelity/test_fidelity.py
@@ -1,7 +1,5 @@
 import math
 
-import pytest
-
 from bloqade import qasm2
 from bloqade.noise import native
 from bloqade.analysis.fidelity import FidelityAnalysis
@@ -115,7 +113,6 @@ def test_c_noise():
     ) * (1 - p_loss)
 
 
-@pytest.mark.xfail
 def test_if():
 
     @noise_main
@@ -176,7 +173,6 @@ def test_if():
     )
 
 
-@pytest.mark.xfail
 def test_for():
 
     @noise_main


### PR DESCRIPTION
Needs #267 in order for tests to pass.

Also, I'm doing quite some hacky stuff right now:
@weinbe58 When invoking a nested kernel via `run_method`, I have to re-run the address analysis in order to be able to access the qubit addresses from the `addr_frame` when running the analysis for the nested method. Afterwards, I have to reset. That's super ugly and feels like a hack. Do you know a better way to do this?

Similarly, the `post_succ_hook` is also run when calling `run_method`. Since I'm updating stuff in-place there, I want to avoid that. I've achieved that via a similar hack setting a boolean flag.