### PR TITLE
enable squin -> stim tests and fix imports from latest stim module shuffle

### DIFF
--- a/src/bloqade/squin/rewrite/qubit_to_stim.py
+++ b/src/bloqade/squin/rewrite/qubit_to_stim.py
@@ -1,8 +1,8 @@
 from kirin import ir
 from kirin.rewrite.abc import RewriteRule, RewriteResult
 
-from bloqade import stim
 from bloqade.squin import op, qubit
+from bloqade.stim.dialects import collapse
 from bloqade.squin.rewrite.wrap_analysis import AddressAttribute
 from bloqade.squin.rewrite.stim_rewrite_util import (
     SQUIN_STIM_GATE_MAPPING,
@@ -75,7 +75,7 @@ class SquinQubitToStim(RewriteRule):
         if qubit_idx_ssas is None:
             return RewriteResult()
 
-        stim_rz_stmt = stim.collapse.stmts.RZ(targets=qubit_idx_ssas)
+        stim_rz_stmt = collapse.stmts.RZ(targets=qubit_idx_ssas)
         reset_stmt.replace_by(stim_rz_stmt)
 
         return RewriteResult(has_done_something=True)

--- a/src/bloqade/squin/rewrite/squin_measure.py
+++ b/src/bloqade/squin/rewrite/squin_measure.py
@@ -3,8 +3,8 @@ from kirin import ir
 from kirin.dialects import py
 from kirin.rewrite.abc import RewriteRule, RewriteResult
 
-from bloqade import stim
 from bloqade.squin import wire, qubit
+from bloqade.stim.dialects import collapse
 from bloqade.squin.rewrite.wrap_analysis import AddressAttribute
 from bloqade.squin.rewrite.stim_rewrite_util import (
     is_measure_result_used,
@@ -38,7 +38,7 @@ class SquinMeasureToStim(RewriteRule):
             return RewriteResult()
 
         prob_noise_stmt = py.constant.Constant(0.0)
-        stim_measure_stmt = stim.collapse.MZ(
+        stim_measure_stmt = collapse.MZ(
             p=prob_noise_stmt.result,
             targets=qubit_idx_ssas,
         )
@@ -59,8 +59,8 @@ class SquinMeasureToStim(RewriteRule):
             return RewriteResult()
 
         error_p_stmt = py.Constant(0.0)
-        stim_mz_stmt = stim.collapse.MZ(targets=qubit_idx_ssas, p=error_p_stmt.result)
-        stim_rz_stmt = stim.collapse.RZ(
+        stim_mz_stmt = collapse.MZ(targets=qubit_idx_ssas, p=error_p_stmt.result)
+        stim_rz_stmt = collapse.RZ(
             targets=qubit_idx_ssas,
         )
 

--- a/src/bloqade/squin/rewrite/wire_to_stim.py
+++ b/src/bloqade/squin/rewrite/wire_to_stim.py
@@ -1,8 +1,8 @@
 from kirin import ir
 from kirin.rewrite.abc import RewriteRule, RewriteResult
 
-from bloqade import stim
 from bloqade.squin import op, wire
+from bloqade.stim.dialects import collapse
 from bloqade.squin.rewrite.wrap_analysis import AddressAttribute
 from bloqade.squin.rewrite.stim_rewrite_util import (
     SQUIN_STIM_GATE_MAPPING,
@@ -67,7 +67,7 @@ class SquinWireToStim(RewriteRule):
         if qubit_idx_ssas is None:
             return RewriteResult()
 
-        stim_rz_stmt = stim.collapse.stmts.RZ(targets=qubit_idx_ssas)
+        stim_rz_stmt = collapse.stmts.RZ(targets=qubit_idx_ssas)
         reset_stmt.replace_by(stim_rz_stmt)
 
         return RewriteResult(has_done_something=True)

--- a/test/squin/stim/test_stim.py
+++ b/test/squin/stim/test_stim.py
@@ -3,9 +3,10 @@ from kirin.passes import Fold
 from kirin.dialects import py, func, ilist
 
 import bloqade.squin.passes as squin_passes
-from bloqade import stim, qasm2, squin
+from bloqade import qasm2, squin
 from bloqade.analysis import address
 from bloqade.stim.emit import EmitStimMain
+from bloqade.stim.dialects import gate, collapse
 
 
 # Taken gratuitously from Kai's unit test
@@ -31,8 +32,8 @@ def gen_func_from_stmts(stmts, output_type=types.NoneType):
         squin.groups.wired.add(qasm2.core)
         .add(ilist)
         .add(squin.qubit)
-        .add(stim.collapse)
-        .add(stim.gate)
+        .add(collapse)
+        .add(gate)
     )
 
     block = ir.Block(stmts)
@@ -97,7 +98,7 @@ def test_qubit_to_stim():
         constructed_method
     )
 
-    constructed_method.print()
+    # constructed_method.print()
 
     # some problem with stim codegen in terms of
     # stim_prog_str = stim_codegen(constructed_method)
@@ -145,15 +146,12 @@ def test_wire_to_stim():
 
     constructed_method = gen_func_from_stmts(stmts)
 
-    constructed_method.print()
+    # constructed_method.print()
 
     squin_to_stim = squin_passes.SquinToStim(constructed_method.dialects)
     squin_to_stim(constructed_method)
 
-    constructed_method.print()
-
-
-test_wire_to_stim()
+    # constructed_method.print()
 
 
 def test_wire_1q_singular_apply():
@@ -181,12 +179,12 @@ def test_wire_1q_singular_apply():
 
     constructed_method = gen_func_from_stmts(stmts)
 
-    constructed_method.print()
+    # constructed_method.print()
 
     squin_to_stim = squin_passes.SquinToStim(constructed_method.dialects)
     squin_to_stim(constructed_method)
 
-    constructed_method.print()
+    # constructed_method.print()
 
 
 def test_wire_1q():
@@ -220,12 +218,12 @@ def test_wire_1q():
 
     constructed_method = gen_func_from_stmts(stmts)
 
-    constructed_method.print()
+    # constructed_method.print()
 
     squin_to_stim = squin_passes.SquinToStim(constructed_method.dialects)
     squin_to_stim(constructed_method)
 
-    constructed_method.print()
+    # constructed_method.print()
 
 
 def test_broadcast_wire_1q_application():
@@ -266,12 +264,12 @@ def test_broadcast_wire_1q_application():
 
     constructed_method = gen_func_from_stmts(stmts)
 
-    constructed_method.print()
+    # constructed_method.print()
 
     squin_to_stim = squin_passes.SquinToStim(constructed_method.dialects)
     squin_to_stim(constructed_method)
 
-    constructed_method.print()
+    # constructed_method.print()
 
 
 # before ANY rewrite, aggressively inline everything, then do the rewrite
@@ -312,12 +310,12 @@ def test_broadcast_qubit_1q_application():
 
     constructed_method = gen_func_from_stmts(stmts)
 
-    constructed_method.print()
+    # constructed_method.print()
 
     squin_to_stim = squin_passes.SquinToStim(constructed_method.dialects)
     squin_to_stim(constructed_method)
 
-    constructed_method.print()
+    # constructed_method.print()
 
 
 def test_broadcast_control_gate_wire_application():
@@ -359,12 +357,12 @@ def test_broadcast_control_gate_wire_application():
 
     constructed_method = gen_func_from_stmts(stmts)
 
-    constructed_method.print()
+    # constructed_method.print()
 
     squin_to_stim = squin_passes.SquinToStim(constructed_method.dialects)
     squin_to_stim(constructed_method)
 
-    constructed_method.print()
+    # constructed_method.print()
 
 
 def test_wire_control():
@@ -393,12 +391,12 @@ def test_wire_control():
     ]
 
     constructed_method = gen_func_from_stmts(stmts)
-    constructed_method.print()
+    # constructed_method.print()
 
     squin_to_stim = squin_passes.SquinToStim(constructed_method.dialects)
     squin_to_stim(constructed_method)
 
-    constructed_method.print()
+    # constructed_method.print()
 
 
 # Measure being depended on, internal replace_by call
@@ -424,12 +422,12 @@ def test_wire_measure():
     ]
 
     constructed_method = gen_func_from_stmts(stmts)
-    constructed_method.print()
+    # constructed_method.print()
 
     squin_to_stim = squin_passes.SquinToStim(constructed_method.dialects)
-    rewrite_result = squin_to_stim(constructed_method)
-    print(rewrite_result)
-    constructed_method.print()
+    squin_to_stim(constructed_method)
+    # print(rewrite_result)
+    # constructed_method.print()
 
 
 def test_qubit_reset():
@@ -450,12 +448,12 @@ def test_qubit_reset():
     ]
 
     constructed_method = gen_func_from_stmts(stmts)
-    constructed_method.print()
+    # constructed_method.print()
 
     squin_to_stim = squin_passes.SquinToStim(constructed_method.dialects)
-    rewrite_result = squin_to_stim(constructed_method)
-    print(rewrite_result)
-    constructed_method.print()
+    squin_to_stim(constructed_method)
+    # print(rewrite_result)
+    # constructed_method.print()
 
 
 def test_wire_reset():
@@ -476,12 +474,12 @@ def test_wire_reset():
     ]
 
     constructed_method = gen_func_from_stmts(stmts)
-    constructed_method.print()
+    # constructed_method.print()
 
     squin_to_stim = squin_passes.SquinToStim(constructed_method.dialects)
-    rewrite_result = squin_to_stim(constructed_method)
-    print(rewrite_result)
-    constructed_method.print()
+    squin_to_stim(constructed_method)
+    # print(rewrite_result)
+    # constructed_method.print()
 
 
 def test_qubit_measure_and_reset():
@@ -501,15 +499,15 @@ def test_qubit_measure_and_reset():
     ]
 
     constructed_method = gen_func_from_stmts(stmts)
-    constructed_method.print()
+    # constructed_method.print()
 
     # analysis_res, _ = nsites.NSitesAnalysis(constructed_method.dialects).run_analysis(constructed_method)
     # constructed_method.print(analysis=analysis_res.entries)
 
     squin_to_stim = squin_passes.SquinToStim(constructed_method.dialects)
-    rewrite_result = squin_to_stim(constructed_method)
-    print(rewrite_result)
-    constructed_method.print()
+    squin_to_stim(constructed_method)
+    # print(rewrite_result)
+    # constructed_method.print()
 
 
 def test_wire_measure_and_reset():
@@ -530,7 +528,7 @@ def test_wire_measure_and_reset():
     ]
 
     constructed_method = gen_func_from_stmts(stmts)
-    constructed_method.print()
+    # constructed_method.print()
 
     fold_pass = Fold(constructed_method.dialects)
     fold_pass(constructed_method)
@@ -539,9 +537,9 @@ def test_wire_measure_and_reset():
     address_res, _ = address.AddressAnalysis(constructed_method.dialects).run_analysis(
         constructed_method
     )
-    constructed_method.print(analysis=address_res.entries)
+    # constructed_method.print(analysis=address_res.entries)
 
     squin_to_stim = squin_passes.SquinToStim(constructed_method.dialects)
-    rewrite_result = squin_to_stim(constructed_method)
-    print(rewrite_result)
-    constructed_method.print()
+    squin_to_stim(constructed_method)
+    # print(rewrite_result)
+    # constructed_method.print()


### PR DESCRIPTION
@ChenZhao44 brought to my attention a couple things with my squin to stim tests and the existing infrastructure while he was developing things. 

The latest import shuffle from #279 does break my existing work but is very easy to fix. On top of that it turns out the test file I made was never actually run so the import change would have flown under the radar if it had not been for Chen's poking around (: 

I went ahead and commented out the excess printing just so running coverage locally/in CI doesn't end up spitting a bunch of stuff out.