### PR TITLE
Syntax sugar for squin apply statement

### DIFF
--- a/src/bloqade/squin/__init__.py
+++ b/src/bloqade/squin/__init__.py
@@ -1,2 +1,8 @@
-from . import op as op, wire as wire, noise as noise, qubit as qubit
+from . import (
+    op as op,
+    wire as wire,
+    noise as noise,
+    qubit as qubit,
+    lowering as lowering,
+)
 from .groups import wired as wired, kernel as kernel

--- a/src/bloqade/squin/lowering.py
+++ b/src/bloqade/squin/lowering.py
@@ -1,0 +1,41 @@
+import ast
+from dataclasses import dataclass
+
+from kirin import lowering
+from kirin.dialects import ilist
+
+from . import qubit
+
+
+@dataclass(frozen=True)
+class ApplyCallLowering(lowering.FromPythonCall["qubit.Apply"]):
+    """
+    Custom lowering for apply, that turns syntax sugar such as
+    apply(op, q0, q1, ...) into the required apply(op, ilist.IList[q0, q1, ...])
+    """
+
+    def lower(self, stmt: type["qubit.Apply"], state: lowering.State, node: ast.Call):
+        if len(node.args) < 2:
+            raise lowering.BuildError(
+                "Apply requires at least one operator and one qubit as arguments!"
+            )
+        op, *qubits = node.args
+        op_ssa = state.lower(op).expect_one()
+
+        qubits_lowered = [state.lower(qbit).expect_one() for qbit in qubits]
+
+        if len(qubits_lowered) == 1 and qubits_lowered[0].type.is_subseteq(
+            ilist.IListType
+        ):
+            # NOTE: this is a call with just a single argument that is already a list
+            s = stmt(operator=op_ssa, qubits=qubits_lowered[0])
+            result = state.current_frame.push(s)
+        else:
+            # NOTE: multiple values in the call or it's not a list (single qubit)
+            # let's collect them to an ilist
+            qubits_ilist = ilist.New(values=tuple(qubits_lowered))
+            s = stmt(operator=op_ssa, qubits=qubits_ilist.result)
+            result = state.current_frame.push(s)
+            qubits_ilist.insert_before(s)
+
+        return result

--- a/src/bloqade/squin/qubit.py
+++ b/src/bloqade/squin/qubit.py
@@ -7,7 +7,9 @@ Depends on:
 - `kirin.dialects.ilist`: provides the `ilist.IListType` type for lists of qubits.
 """
 
+import ast
 from typing import Any, overload
+from dataclasses import dataclass
 
 from kirin import ir, types, lowering
 from kirin.decl import info, statement
@@ -27,9 +29,43 @@ class New(ir.Statement):
     result: ir.ResultValue = info.result(ilist.IListType[QubitType, types.Any])
 
 
+@dataclass(frozen=True)
+class ApplyCallLowering(lowering.FromPythonCall["Apply"]):
+    """
+    Custom lowering for apply, that turns syntax sugar such as
+    apply(op, q0, q1, ...) into the required apply(op, ilist.IList[q0, q1, ...])
+    """
+
+    def lower(self, stmt: type["Apply"], state: lowering.State, node: ast.Call):
+        if len(node.args) < 2:
+            raise lowering.BuildError(
+                "Apply requires at least one operator and one qubit as arguments!"
+            )
+        op, *qubits = node.args
+        op_ssa = state.lower(op).expect_one()
+
+        qubits_lowered = [state.lower(qbit).expect_one() for qbit in qubits]
+
+        if len(qubits_lowered) == 1 and qubits_lowered[0].type.is_subseteq(
+            ilist.IListType
+        ):
+            # NOTE: this is a call with just a single argument that is already a list
+            s = stmt(operator=op_ssa, qubits=qubits_lowered[0])
+            result = state.current_frame.push(s)
+        else:
+            # NOTE: multiple values in the call or it's not a list (single qubit)
+            # let's collect them to an ilist
+            qubits_ilist = ilist.New(values=tuple(qubits_lowered))
+            s = stmt(operator=op_ssa, qubits=qubits_ilist.result)
+            result = state.current_frame.push(s)
+            qubits_ilist.insert_before(s)
+
+        return result
+
+
 @statement(dialect=dialect)
 class Apply(ir.Statement):
-    traits = frozenset({lowering.FromPythonCall()})
+    traits = frozenset({ApplyCallLowering()})
     operator: ir.SSAValue = info.argument(OpType)
     qubits: ir.SSAValue = info.argument(ilist.IListType[QubitType])
 
@@ -95,7 +131,7 @@ def new(n_qubits: int) -> ilist.IList[Qubit, Any]:
     ...
 
 
-@wraps(Apply)
+@overload
 def apply(operator: Op, qubits: ilist.IList[Qubit, Any] | list[Qubit]) -> None:
     """Apply an operator to a list of qubits.
 
@@ -110,6 +146,27 @@ def apply(operator: Op, qubits: ilist.IList[Qubit, Any] | list[Qubit]) -> None:
         None
     """
     ...
+
+
+@overload
+def apply(operator: Op, *qubits: Qubit) -> None:
+    """Apply and operator to any number of qubits.
+
+    Note, that when considering atom loss, lost qubits will be skipped.
+
+    Args:
+        operator: The operator to apply.
+        *qubits: The qubits to apply the operator to. The number of qubits must
+            match the size of the operator.
+
+    Returns:
+        None
+    """
+    ...
+
+
+@wraps(Apply)
+def apply(operator: Op, *qubits) -> None: ...
 
 
 @overload


### PR DESCRIPTION
Instead of a rewrite, the syntax sugar is removed via custom lowering. This is because we needed custom lowering anyway in order to support the vararg syntax:

```python
def apply(operator: Op, *qubits: Qubit) -> None: ...
```

Let me know if this should be separated into a rewrite, although I think the lowering is still quite simple like this.