### PR TITLE
RFC: Move away from NonDestructiveMeasure in squin.wire dialect name

### DIFF
--- a/src/bloqade/squin/wire.py
+++ b/src/bloqade/squin/wire.py
@@ -100,7 +100,7 @@ class Measure(ir.Statement):
 
 
 @statement(dialect=dialect)
-class NonDestructiveMeasure(ir.Statement):
+class LossResolvingMeasure(ir.Statement):
     traits = frozenset({lowering.FromPythonCall()})
     input_wire: ir.SSAValue = info.argument(WireType)
     result: ir.ResultValue = info.result(types.Int)


### PR DESCRIPTION
On the heels of @weinbe58 's request and input from @cduck this PR just proposes moving away from the old NonDestructiveMeasure name (which caused some confusion over what exactly was being "destroyed") and opting for something a bit clearer. 

I remember there weren't any objections to something along the lines of "Loss Resolving Readout" so I propose Loss Resolving "Measure" but perhaps there might be some objections or other ideas. I don't know if it would be helpful either to "flip" the intent behind the measures (potential via renaming the default Measure) considering @cduck has mentioned Loss Resolution is the more common, normal mode of operation as opposed to the destructive/"lossy" form. 