### PR TITLE
Adding reg as a value inside of AddressQubit element. 

### DIFF
--- a/src/bloqade/analysis/address/impls.py
+++ b/src/bloqade/analysis/address/impls.py
@@ -85,7 +85,7 @@ class PyIndexing(interp.MethodTable):
         # an AddressReg is guaranteed to just have some sequence
         # of integers which is directly pluggable to AddressQubit
         elif isinstance(obj, AddressReg):
-            return (AddressQubit(obj.data[idx]),)
+            return (AddressQubit(reg=obj, data=obj.data[idx]),)
         else:
             return (NotQubit(),)
 

--- a/src/bloqade/analysis/address/lattice.py
+++ b/src/bloqade/analysis/address/lattice.py
@@ -66,6 +66,7 @@ class AddressReg(Address):
 @final
 @dataclass
 class AddressQubit(Address):
+    reg: AddressReg
     data: int
 
     def is_subseteq(self, other: Address) -> bool:

--- a/src/bloqade/qasm2/dialects/core/address.py
+++ b/src/bloqade/qasm2/dialects/core/address.py
@@ -33,6 +33,6 @@ class AddressMethodTable(interp.MethodTable):
         pos = interp.get_const_value(int, stmt.idx)
         if isinstance(addr, AddressReg):
             global_idx = addr.data[pos]
-            return (AddressQubit(global_idx),)
+            return (AddressQubit(reg=addr, data=global_idx),)
         else:  # this is not reachable
             return (NotQubit(),)


### PR DESCRIPTION
I want to add this because on the case of trying to implement the rewtie in #270 you need to check if all qubits come from the same register value if they are inside an `AddressTuple` lattice element. Here the `AddressQubit` as a reference to the register object it comes from and so its possible to figure out just from `AddressTuple` locally if all the elements of an `AddressReg` are inside the `AddressTuple`. 