### PR TITLE
Lowering cirq's depolarize channels to squin

### DIFF
--- a/src/bloqade/squin/cirq/lowering.py
+++ b/src/bloqade/squin/cirq/lowering.py
@@ -389,3 +389,41 @@ class Squin(lowering.LoweringABC[CirqNode]):
         )
 
         return noise_channel
+
+    def visit_DepolarizingChannel(
+        self, state: lowering.State[CirqNode], node: cirq.DepolarizingChannel
+    ):
+        p = state.current_frame.push(py.Constant(node.p)).result
+        return state.current_frame.push(noise.stmts.Depolarize(p))
+
+    def visit_AsymmetricDepolarizingChannel(
+        self, state: lowering.State[CirqNode], node: cirq.AsymmetricDepolarizingChannel
+    ):
+        nqubits = node.num_qubits()
+        if nqubits > 2:
+            raise lowering.BuildError(
+                "AsymmetricDepolarizingChannel applied to more than 2 qubits is not supported!"
+            )
+
+        if nqubits == 1:
+            p_x = state.current_frame.push(py.Constant(node.p_x)).result
+            p_y = state.current_frame.push(py.Constant(node.p_y)).result
+            p_z = state.current_frame.push(py.Constant(node.p_z)).result
+            params = state.current_frame.push(ilist.New(values=(p_x, p_y, p_z))).result
+            return state.current_frame.push(noise.stmts.SingleQubitPauliChannel(params))
+
+        # NOTE: nqubits == 2
+        error_probs = node.error_probabilities
+        paulis = ("I", "X", "Y", "Z")
+        values = []
+        for p1 in paulis:
+            for p2 in paulis:
+                if p1 == p2 == "I":
+                    continue
+
+                p = error_probs.get(p1 + p2, 0.0)
+                p_ssa = state.current_frame.push(py.Constant(p)).result
+                values.append(p_ssa)
+
+        params = state.current_frame.push(ilist.New(values=values)).result
+        return state.current_frame.push(noise.stmts.TwoQubitPauliChannel(params))

--- a/test/squin/cirq/test_cirq_to_squin.py
+++ b/test/squin/cirq/test_cirq_to_squin.py
@@ -127,6 +127,17 @@ def noise_channels():
     )
 
 
+def depolarizing_channels():
+    q = cirq.LineQubit.range(2)
+
+    return cirq.Circuit(
+        cirq.depolarize(0.1)(q[0]),
+        cirq.asymmetric_depolarize(p_x=0.1)(q[0]),
+        cirq.asymmetric_depolarize(error_probabilities={"XY": 0.1})(*q),
+        cirq.measure(q),
+    )
+
+
 def nested_circuit():
     q = cirq.LineQubit.range(3)
 


### PR DESCRIPTION
Turns out I missed `cirq.DepolarizingChannel` and `cirq.AsymmetricDepolarizingChannel` in the squin lowering implementation in my previous PR. Here they are.