### PR TITLE
Allow slicing to work with address analysis

### DIFF
--- a/test/analysis/address/test_analysis.py
+++ b/test/analysis/address/test_analysis.py
@@ -236,9 +236,6 @@ def test_slice():
     assert address_qubits[0] == address.AddressQubit(data=1)
 
 
-test_slice()
-
-
 def test_for_loop():
     @squin.kernel
     def main():


### PR DESCRIPTION
This allows slicing to work with the address analysis pass.

@liupengy19 ran into this problem with some of his work and @david-pl helped me confirm the issue was not specific to my setup (: 

Note: the way the tests are written for the address analysis are definitely a bit outdated, I believe once #370 goes through I updated the tests there so it will just be a matter of merging in the new updated stuff