### PR TITLE
Fix warning about invalid escape sequence

### DIFF
--- a/src/bloqade/squin/op/stmts.py
+++ b/src/bloqade/squin/op/stmts.py
@@ -133,7 +133,7 @@ class ShiftOp(PrimitiveOp):
     A phase shift operator.
 
     $$
-    Shift(\\theta) = \\begin{bmatrix} 1 & 0 \\\\ 0 & e^{i \\theta} \\end{bmatrix}
+    \\text{Shift}(\\theta) = \\begin{bmatrix} 1 & 0 \\\\ 0 & e^{i \\theta} \\end{bmatrix}
     $$
     """
 

--- a/src/bloqade/squin/op/stmts.py
+++ b/src/bloqade/squin/op/stmts.py
@@ -103,7 +103,7 @@ class U3(PrimitiveOp):
     Note that we use the convention from the QASM2 specification, namely
 
     $$
-    U_3(\theta, \phi, \lambda) = R_z(\phi) R_y(\theta) R_z(\lambda)
+    U_3(\\theta, \\phi, \\lambda) = R_z(\\phi) R_y(\\theta) R_z(\\lambda)
     $$
     """
 
@@ -119,7 +119,7 @@ class PhaseOp(PrimitiveOp):
     A phase operator.
 
     $$
-    PhaseOp(\theta) = e^{i \theta} I
+    PhaseOp(\\theta) = e^{i \\theta} I
     $$
     """
 
@@ -133,7 +133,7 @@ class ShiftOp(PrimitiveOp):
     A phase shift operator.
 
     $$
-    Shift(\theta) = \\begin{bmatrix} 1 & 0 \\\\ 0 & e^{i \\theta} \\end{bmatrix}
+    Shift(\\theta) = \\begin{bmatrix} 1 & 0 \\\\ 0 & e^{i \\theta} \\end{bmatrix}
     $$
     """
 
@@ -144,7 +144,7 @@ class ShiftOp(PrimitiveOp):
 @statement(dialect=dialect)
 class Reset(PrimitiveOp):
     """
-    Reset operator for qubits or wires.
+    Reset operator for qubits and wires.
     """
 
     traits = frozenset({ir.Pure(), lowering.FromPythonCall(), FixedSites(1)})

--- a/src/bloqade/squin/op/stmts.py
+++ b/src/bloqade/squin/op/stmts.py
@@ -119,7 +119,7 @@ class PhaseOp(PrimitiveOp):
     A phase operator.
 
     $$
-    PhaseOp(\\theta) = e^{i \\theta} I
+    \\text{PhaseOp}(\\theta) = e^{i \\theta} I
     $$
     """
 


### PR DESCRIPTION
I noticed a warning about `\p` being an invalid escape sequence when running unit tests locally and found it came from the way the docstrings in the squin ops were being defined. 

This should get rid of the warning as well as fix the rendering on the docs page, which has some incorrect rendering:

<img width="334" height="70" alt="Screenshot 2025-07-15 at 08 04 23" src="https://github.com/user-attachments/assets/c644dbf4-ff58-4bcd-bf33-640c32a6c8c6" />
<img width="185" height="77" alt="Screenshot 2025-07-15 at 08 04 32" src="https://github.com/user-attachments/assets/10d2791b-7dcb-47af-850a-0d6ddf4ce111" />
