### PR TITLE
Fix qubit.apply lowering with multiple qubit indexing operations

### DIFF
--- a/src/bloqade/squin/rewrite/desugar.py
+++ b/src/bloqade/squin/rewrite/desugar.py
@@ -68,8 +68,6 @@ class ApplyDesugarRule(RewriteRule):
         ):
             qubits_ilist = qubits[0]
 
-        # qubits is just a single SSA Val right now, fails the above checks in that
-        # the first element of the tuple is not a QubitType or an IListType of qubits
         elif len(qubits) == 1:
             # TODO: remove this elif clause once we're at kirin v0.18
             # NOTE: this is a temporary workaround for kirin#408
@@ -81,12 +79,7 @@ class ApplyDesugarRule(RewriteRule):
 
             is_ilist = isinstance(qbit_stmt := qubits[0].stmt, ilist.New)
 
-            # Confirm your qubits are in an IList and of the form: [<qubits>]
             if is_ilist:
-                # This trips up [q[i], q[i+1]]. It is an ilist but the length is greater than 1.
-                ## We don't need this anymore if we're extending the logic to put into a loop
-                # if len(qbit_stmt.values) != 1:
-                #    return RewriteResult()
 
                 if not all(
                     isinstance(qbit_getindex_result, ir.ResultValue)
@@ -110,7 +103,6 @@ class ApplyDesugarRule(RewriteRule):
                 return RewriteResult()
 
             # The GetItem should have been applied on something that returns an IList of Qubits
-
             if any(
                 not qbit_getindex.obj.type.is_subseteq(
                     ilist.IListType[QubitType, types.Any]

--- a/src/bloqade/squin/rewrite/desugar.py
+++ b/src/bloqade/squin/rewrite/desugar.py
@@ -54,7 +54,9 @@ class ApplyDesugarRule(RewriteRule):
         qubits = node.qubits
 
         if len(qubits) > 1 and all(q.type.is_subseteq(QubitType) for q in qubits):
-            (qubits_ilist_stmt := ilist.New(qubits)).insert_before(node)
+            (qubits_ilist_stmt := ilist.New(qubits)).insert_before(
+                node
+            )  # qubits is just a tuple of SSAValues
             qubits_ilist = qubits_ilist_stmt.result
 
         elif len(qubits) == 1 and qubits[0].type.is_subseteq(QubitType):
@@ -66,6 +68,8 @@ class ApplyDesugarRule(RewriteRule):
         ):
             qubits_ilist = qubits[0]
 
+        # qubits is just a single SSA Val right now, fails the above checks in that
+        # the first element of the tuple is not a QubitType or an IListType of qubits
         elif len(qubits) == 1:
             # TODO: remove this elif clause once we're at kirin v0.18
             # NOTE: this is a temporary workaround for kirin#408
@@ -76,34 +80,50 @@ class ApplyDesugarRule(RewriteRule):
                 return RewriteResult()
 
             is_ilist = isinstance(qbit_stmt := qubits[0].stmt, ilist.New)
-            if is_ilist:
-                if len(qbit_stmt.values) != 1:
-                    return RewriteResult()
 
-                if not isinstance(
-                    qbit_getindex_result := qbit_stmt.values[0], ir.ResultValue
+            # Confirm your qubits are in an IList and of the form: [<qubits>]
+            if is_ilist:
+                # This trips up [q[i], q[i+1]]. It is an ilist but the length is greater than 1.
+                ## We don't need this anymore if we're extending the logic to put into a loop
+                # if len(qbit_stmt.values) != 1:
+                #    return RewriteResult()
+
+                if not all(
+                    isinstance(qbit_getindex_result, ir.ResultValue)
+                    for qbit_getindex_result in qbit_stmt.values
                 ):
                     return RewriteResult()
 
-                qbit_getindex = qbit_getindex_result.stmt
+                # Get the parent statement that the qubit came from
+                # (should be a GetItem instance, see logic below)
+                qbit_getindices = [
+                    qbit_getindex_result.stmt
+                    for qbit_getindex_result in qbit_stmt.values
+                ]
             else:
-                qbit_getindex = qubits[0].stmt
+                qbit_getindices = [qubit.stmt for qubit in qubits]
 
-            if not isinstance(qbit_getindex, py.indexing.GetItem):
+            if any(
+                not isinstance(qbit_getindex, py.indexing.GetItem)
+                for qbit_getindex in qbit_getindices
+            ):
                 return RewriteResult()
 
-            if not qbit_getindex.obj.type.is_subseteq(
-                ilist.IListType[QubitType, types.Any]
+            # The GetItem should have been applied on something that returns an IList of Qubits
+
+            if any(
+                not qbit_getindex.obj.type.is_subseteq(
+                    ilist.IListType[QubitType, types.Any]
+                )
+                for qbit_getindex in qbit_getindices
             ):
                 return RewriteResult()
 
             if is_ilist:
-                values = qbit_stmt.values
+                qubits_ilist = qbit_stmt.result
             else:
-                values = [qubits[0]]
-
-            (qubits_ilist_stmt := ilist.New(values=values)).insert_before(node)
-            qubits_ilist = qubits_ilist_stmt.result
+                (qubits_ilist_stmt := ilist.New(values=[qubits[0]])).insert_before(node)
+                qubits_ilist = qubits_ilist_stmt.result
         else:
             return RewriteResult()
 

--- a/test/squin/test_sugar.py
+++ b/test/squin/test_sugar.py
@@ -46,7 +46,7 @@ def test_apply_sugar():
         h = squin.op.h()
         x = squin.op.x()
 
-        # test applying to lest with getindex
+        # test applying to list with getindex
         squin.qubit.apply(x, [q[0]])
 
         # test apply with ast.Name
@@ -89,3 +89,18 @@ def test_apply_in_for_loop():
 
     assert math.isclose(abs(ket[0]) ** 2, 1, abs_tol=1e-7)
     assert ket[1] == ket[2] == ket[3] == 0
+
+
+def test_apply_in_for_loop_index_multiple_index():
+
+    @squin.kernel
+    def main():
+        q = squin.qubit.new(3)
+        squin.qubit.apply(squin.op.h(), q[0])
+        cx = squin.op.cx()
+        for i in range(2):
+            squin.qubit.apply(cx, [q[i], q[i + 1]])
+
+    sim = StackMemorySimulator(min_qubits=3)
+    ket = sim.state_vector(main)
+    assert math.isclose(abs(ket[0]) ** 2, 0.5, abs_tol=1e-5)


### PR DESCRIPTION
When more than one qubit indexing operation is present, the lowering for `squin.qubit.apply` falls through which causes issues in the squin to stim infrastructure.

To be precise, a statement like:
```python
qubit.apply(op.some_gate, [list_of_qubits[i]])
```
Is fine but @liupengy19 helped identify that something like:
```python
qubit.apply(op.some_gate, [q[i], q[i+1])
```
causes problems.

With help from @david-pl and @kaihsin I was able to figure out that some of the existing lowering logic just needed to be made a bit more flexible (: 