### PR TITLE
Clearly document the units of angles in wrappers

### DIFF
--- a/src/bloqade/squin/op/_wrapper.py
+++ b/src/bloqade/squin/op/_wrapper.py
@@ -50,15 +50,33 @@ def identity(*, sites: int) -> types.Op: ...
 
 
 @wraps(stmts.Rot)
-def rot(axis: types.Op, angle: float) -> types.Op: ...
+def rot(axis: types.Op, angle: float) -> types.Op:
+    """Rotation around axis by the specified angle (in radian units), i.e."""
+    ...
 
 
 @wraps(stmts.ShiftOp)
-def shift(theta: float) -> types.Op: ...
+def shift(theta: float) -> types.Op:
+    """Phase shift operator, that shifts the phase with the given angle theta (in radian units), i.e.
+
+    $$
+    |1\\rangle \\to e^{i\\theta} |1\\rangle
+    $$
+
+    while leaving the state $$|0\\rangle$$ unchanged.
+    """
+    ...
 
 
 @wraps(stmts.PhaseOp)
-def phase(theta: float) -> types.Op: ...
+def phase(theta: float) -> types.Op:
+    """Phase operator, that applies the phase factor with the given angle theta (in radian units), i.e.
+
+    $$
+    |\\psi\\rangle \\to e^{i\\theta} |\\psi\\rangle
+    $$
+    """
+    ...
 
 
 @wraps(stmts.X)
@@ -114,7 +132,14 @@ def spin_p() -> types.Op: ...
 
 
 @wraps(stmts.U3)
-def u(theta: float, phi: float, lam: float) -> types.Op: ...
+def u(theta: float, phi: float, lam: float) -> types.Op:
+    """The three-axis rotation operator (all angles are given in radian units), defined as
+
+    $$
+    U_3(\\theta, \\phi, \\lambda) = R_z(\\phi) R_y(\\theta) R_z(\\lambda)
+    $$
+    """
+    ...
 
 
 @wraps(stmts.PauliString)

--- a/src/bloqade/squin/stdlib/gate.py
+++ b/src/bloqade/squin/stdlib/gate.py
@@ -175,27 +175,34 @@ def ch(control: Qubit, target: Qubit) -> None:
 
 @kernel
 def u(theta: float, phi: float, lam: float, qubit: Qubit) -> None:
-    """3D rotation gate applied to control and target"""
+    """3D rotation gate applied to a qubit. All angles are in radian units.
+
+    The rotation is defined as
+
+    $$
+    U_3(\\theta, \\phi, \\lambda) = R_z(\\phi) R_y(\\theta) R_z(\\lambda)
+    $$
+    """
     op = _op.u(theta, phi, lam)
     _qubit.apply(op, qubit)
 
 
 @kernel
 def rx(theta: float, qubit: Qubit) -> None:
-    """Rotation X gate applied to qubit."""
+    """Rotation X gate by an angle `theta` in radian units applied to qubit."""
     op = _op.rot(_op.x(), theta)
     _qubit.apply(op, qubit)
 
 
 @kernel
 def ry(theta: float, qubit: Qubit) -> None:
-    """Rotation Y gate applied to qubit."""
+    """Rotation Y gate by an angle `theta` in radian units applied to qubit."""
     op = _op.rot(_op.y(), theta)
     _qubit.apply(op, qubit)
 
 
 @kernel
 def rz(theta: float, qubit: Qubit) -> None:
-    """Rotation Z gate applied to qubit."""
+    """Rotation Z gate by an angle `theta` in radian units applied to qubit."""
     op = _op.rot(_op.z(), theta)
     _qubit.apply(op, qubit)


### PR DESCRIPTION
Closes #329 .

@Roger-luo I'm wondering whether this is sufficient. There was no documentation before so maybe that was just the issue. I don't know, I just really dislike the idea of having e.g. `rot_rad`. It also doesn't make complete sense since there is another argument there that's not an angle. I will change to that if you think just having nice docstrings is insufficient.