### PR TITLE
Remove the custom for loop unroll pass in stim passes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ requires-python = ">=3.10"
 dependencies = [
     "numpy>=1.22.0",
     "scipy>=1.13.1",
-    "kirin-toolchain~=0.17.17",
+    "kirin-toolchain~=0.17.23",
     "rich>=13.9.4",
     "pydantic>=1.3.0,<2.11.0",
     "pandas>=2.2.3",

--- a/src/bloqade/stim/passes/__init__.py
+++ b/src/bloqade/stim/passes/__init__.py
@@ -1,5 +1,4 @@
 from .squin_to_stim import (
     SquinToStimPass as SquinToStimPass,
     StimSimplifyIfs as StimSimplifyIfs,
-    AggressiveForLoopUnroll as AggressiveForLoopUnroll,
 )


### PR DESCRIPTION
There's still one test that errors and I'm not sure why:

```python
FAILED test/stim/passes/test_squin_qubit_to_stim.py::test_non_pure_loop_iterator - KeyError: <BlockArgument[int] rnd, uses: 1>
````