### PR TITLE
Simplyfing `qubit.new`

### DIFF
--- a/src/bloqade/squin/__init__.py
+++ b/src/bloqade/squin/__init__.py
@@ -8,6 +8,7 @@ from . import (
     _typeinfer as _typeinfer,
 )
 from .groups import wired as wired, kernel as kernel
+from .stdlib.qubit import new as new
 from .stdlib.simple import (
     h as h,
     s as s,

--- a/src/bloqade/squin/analysis/address_impl.py
+++ b/src/bloqade/squin/analysis/address_impl.py
@@ -69,3 +69,14 @@ class SquinQubitMethodTable(interp.MethodTable):
         addr = AddressReg(range(interp_.next_address, interp_.next_address + n_qubits))
         interp_.next_address += n_qubits
         return (addr,)
+
+    @interp.impl(qubit.NewQubit)
+    def new_qubit(
+        self,
+        interp_: AddressAnalysis,
+        frame: ForwardFrame[Address],
+        stmt: qubit.NewQubit,
+    ):
+        addr = AddressQubit(interp_.next_address)
+        interp_.next_address += 1
+        return (addr,)

--- a/src/bloqade/squin/qubit.py
+++ b/src/bloqade/squin/qubit.py
@@ -30,6 +30,12 @@ class New(ir.Statement):
 
 
 @statement(dialect=dialect)
+class NewQubit(ir.Statement):
+    traits = frozenset({lowering.FromPythonCall()})
+    result: ir.ResultValue = info.result(QubitType)
+
+
+@statement(dialect=dialect)
 class Apply(ir.Statement):
     traits = frozenset({lowering.FromPythonCall()})
     operator: ir.SSAValue = info.argument(OpType)
@@ -102,6 +108,16 @@ def new(n_qubits: int) -> ilist.IList[Qubit, Any]:
 
     Returns:
         (ilist.IList[Qubit, n_qubits]) A list of qubits.
+    """
+    ...
+
+
+@wraps(NewQubit)
+def new_qubit() -> Qubit:
+    """Create a new qubit.
+
+    Returns:
+        Qubit: A new qubit.
     """
     ...
 

--- a/src/bloqade/squin/stdlib/qubit.py
+++ b/src/bloqade/squin/stdlib/qubit.py
@@ -1,0 +1,21 @@
+from kirin.dialects import ilist
+
+from .. import kernel
+from ..qubit import new_qubit
+
+
+@kernel
+def new(n_qubits: int):
+    """Create a new list of qubits.
+
+    Args:
+        n_qubits(int): The number of qubits to create.
+
+    Returns:
+        (ilist.IList[Qubit, n_qubits]) A list of qubits.
+    """
+
+    def _new(qid: int):
+        return new_qubit()
+
+    return ilist.map(_new, ilist.range(n_qubits))


### PR DESCRIPTION
Closes #508 however I am not sure where to reexport `new` since I Can't reexport it into the `qubit` module. For now I have re-exported it into `squin.new`. 