### PR TITLE
Add more detailed AssertionError for non GridQubits in conflict graph…

### DIFF
--- a/src/bloqade/cirq_utils/noise/model.py
+++ b/src/bloqade/cirq_utils/noise/model.py
@@ -357,10 +357,10 @@ class GeminiOneZoneNoiseModelConflictGraphMoves(GeminiOneZoneNoiseModel):
     def noisy_moment(self, moment, system_qubits):
         # Moment with original ops
         original_moment = moment
-        assert np.all(
-            [isinstance(q, cirq.GridQubit) for q in system_qubits]
-        ), ("Found a qubit that is not a GridQubit. In order for the conflict graph to know the qubit geometry, "
-            "all qubits in the circuit must be defined as cirq.GridQubit objects.")
+        assert np.all([isinstance(q, cirq.GridQubit) for q in system_qubits]), (
+            "Found a qubit that is not a GridQubit. In order for the conflict graph to know the qubit geometry, "
+            "all qubits in the circuit must be defined as cirq.GridQubit objects."
+        )
         # Check if the moment is empty
         if len(moment.operations) == 0:
             move_moments = []

--- a/src/bloqade/cirq_utils/noise/model.py
+++ b/src/bloqade/cirq_utils/noise/model.py
@@ -359,7 +359,8 @@ class GeminiOneZoneNoiseModelConflictGraphMoves(GeminiOneZoneNoiseModel):
         original_moment = moment
         assert np.all(
             [isinstance(q, cirq.GridQubit) for q in system_qubits]
-        ), "Found a qubit that is not a GridQubit."
+        ), ("Found a qubit that is not a GridQubit. In order for the conflict graph to know the qubit geometry, "
+            "all qubits in the circuit must be defined as cirq.GridQubit objects.")
         # Check if the moment is empty
         if len(moment.operations) == 0:
             move_moments = []


### PR DESCRIPTION
Our partner has provided feedback that the error (when GeminiOneZoneNoiseModelConflictGraphMoves is called on a circuit that is not solely containing cirq.GridQubits) is not descriptive enough. I've added another sentence.