### PR TITLE
Fix cirq lowering for classical control

### DIFF
--- a/src/bloqade/squin/cirq/lowering.py
+++ b/src/bloqade/squin/cirq/lowering.py
@@ -226,8 +226,16 @@ class Squin(lowering.LoweringABC[CirqNode]):
         # NOTE: remove stmt from parent block
         then_stmt.detach()
         then_body = ir.Block((then_stmt,))
+        then_body.args.append_from(types.Bool, name="cond")
+        then_body.stmts.append(scf.Yield())
 
-        return state.current_frame.push(scf.IfElse(condition, then_body=then_body))
+        else_body = ir.Block(())
+        else_body.args.append_from(types.Bool, name="cond")
+        else_body.stmts.append(scf.Yield())
+
+        return state.current_frame.push(
+            scf.IfElse(condition, then_body=then_body, else_body=else_body)
+        )
 
     def visit_SingleQubitPauliStringGateOperation(
         self,


### PR DESCRIPTION
This is a backport since it already works on main. It's sort of a bug in kirin, but we can also fix it here. The issue is that the API allows you to set the `else_body` as `None`, but this is not actually possible.