### PR TITLE
DeadCodeElimination after InlineGetItem

### DIFF
--- a/src/bloqade/rewrite/passes/aggressive_unroll.py
+++ b/src/bloqade/rewrite/passes/aggressive_unroll.py
@@ -42,6 +42,7 @@ class Fold(Pass):
             ilist.rewrite.InlineGetItem(),
             ilist.rewrite.FlattenAdd(),
             ilist.rewrite.HintLen(),
+            DeadCodeElimination(),
         )
         result = Fixpoint(Walk(rule)).rewrite(mt.code).join(result)
 

--- a/src/bloqade/rewrite/passes/canonicalize_ilist.py
+++ b/src/bloqade/rewrite/passes/canonicalize_ilist.py
@@ -5,6 +5,7 @@ from kirin.rewrite import (
     Walk,
     Chain,
     Fixpoint,
+    DeadCodeElimination,
 )
 from kirin.dialects.ilist import rewrite
 
@@ -24,6 +25,7 @@ class CanonicalizeIList(passes.Pass):
                     rewrite.InlineGetItem(),
                     rewrite.FlattenAdd(),
                     rewrite.HintLen(),
+                    DeadCodeElimination(),
                 )
             )
         ).rewrite(mt.code)


### PR DESCRIPTION
Dead code should always be eliminated in fix point loops after InlineGetItem. See discussion of https://github.com/QuEraComputing/kirin/pull/557