### PR TITLE
Fix AggressiveUnroll again

### DIFF
--- a/src/bloqade/rewrite/passes/aggressive_unroll.py
+++ b/src/bloqade/rewrite/passes/aggressive_unroll.py
@@ -71,7 +71,9 @@ class AggressiveUnroll(Pass):
     def unsafe_run(self, mt: Method) -> RewriteResult:
         result = RewriteResult()
         result = self.fold.unsafe_run(mt).join(result)
-        result = Walk(ilist.rewrite.Unroll()).rewrite(mt.code).join(result)  # BUG: cduck's use case fails without this line
+        result = (
+            Walk(ilist.rewrite.Unroll()).rewrite(mt.code).join(result)
+        )  # BUG: cduck's use case fails without this line
         result = self.scf_unroll.unsafe_run(mt).join(result)
         self.typeinfer.unsafe_run(
             mt

--- a/src/bloqade/rewrite/passes/aggressive_unroll.py
+++ b/src/bloqade/rewrite/passes/aggressive_unroll.py
@@ -71,6 +71,7 @@ class AggressiveUnroll(Pass):
     def unsafe_run(self, mt: Method) -> RewriteResult:
         result = RewriteResult()
         result = self.fold.unsafe_run(mt).join(result)
+        result = Walk(ilist.rewrite.Unroll()).rewrite(mt.code).join(result)  # BUG: cduck's use case fails without this line
         result = self.scf_unroll.unsafe_run(mt).join(result)
         self.typeinfer.unsafe_run(
             mt


### PR DESCRIPTION
Do not merge until we understand the issue being fixed here.  This became an issue again while upgrading my code for bloqade-circuit v0.9.

This pass has been unreliable before (see #593) and I'm not sure why adding a second copy of the `ilist.rewrite.Unroll` pass fixes the issue.

Here's the error it is fixing:
```python
  File "test.py", line 59, in compile_to_stim
    SquinToStimPass(main.dialects, no_raise=no_raise)(main)
  File "kirin/passes/abc.py", line 30, in __call__
    result = self.unsafe_run(mt)
  File "bloqade/stim/passes/squin_to_stim.py", line 71, in unsafe_run
    .rewrite(mt.code)
  File "kirin/rewrite/chain.py", line 29, in rewrite
    result = rule.rewrite(node)
  File "kirin/rewrite/walk.py", line 40, in rewrite
    result = self.rule.rewrite(subnode)
  File "kirin/rewrite/abc.py", line 38, in rewrite
    return self.rewrite_Statement(cast(Statement, node))
  File "bloqade/stim/rewrite/set_observable_to_stim.py", line 26, in rewrite_Statement
    return self.rewrite_SetObservable(node)
  File "bloqade/stim/rewrite/set_observable_to_stim.py", line 39, in rewrite_SetObservable
    measure_ids = self.measure_id_frame.entries[node.measurements]
KeyError: <ResultValue[IList[MeasurementResult, AnyType()]] inputs, uses: 1>
```

Tagging: @kaihsin