### PR TITLE
Backport import path fix

### DIFF
--- a/src/bloqade/stim/passes/flatten.py
+++ b/src/bloqade/stim/passes/flatten.py
@@ -5,7 +5,7 @@ from kirin import ir
 from kirin.passes import Pass
 from kirin.rewrite.abc import RewriteResult
 
-from bloqade.qasm2.passes.fold import AggressiveUnroll
+from bloqade.rewrite.passes import AggressiveUnroll
 from bloqade.stim.passes.simplify_ifs import StimSimplifyIfs
 
 


### PR DESCRIPTION
This is a backport of #620 requested by @cduck . 

Mitigates the need to have `lark` installed just to have access to the pass!