### PR TITLE
Fix a build issue on python 3.12.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ qbraid = [
 ]
 cirq = [
     "cirq-core>=1.4.1",
+    "numba>=0.63.1",
     "cirq-core[contrib]>=1.4.1",
     "qpsolvers[clarabel]>=4.7.0",
 ]


### PR DESCRIPTION
Fixes an install issue, where for some reason `bloqade-circuit[cirq]` tries to pull in an outdated numba version causing the build to fail.