### PR TITLE
Pin the pyqrack version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "rich>=13.9.4",
     "pydantic>=1.3.0,<2.11.0",
     "pandas>=2.2.3",
-    "pyqrack-cpu>=1.70.4",
+    "pyqrack-cpu>=1.70.4,<=1.81",
 ]
 
 [project.optional-dependencies]
@@ -42,10 +42,10 @@ cirq = [
     "qpsolvers[clarabel]>=4.7.0",
 ]
 pyqrack-opencl = [
-    "pyqrack>=1.70.4",
+    "pyqrack>=1.70.4,<=1.81",
 ]
 pyqrack-cuda = [
-    "pyqrack-cuda>=1.70.4",
+    "pyqrack-cuda>=1.70.4,<=1.81",
 ]
 stim = [
     "stim>=1.15.0",


### PR DESCRIPTION
v1.82 of pyqrack removed the `QrackSimulator.is_tensor_network` attribute, which we use in a check. I filed an upstream issue to check whether this was on purpose and what the alternative should be. The issue is here https://github.com/unitaryfoundation/pyqrack/issues/42

For now, I'm just bounding the version.