### PR TITLE
Fix factor of 2 in phased xz

### DIFF
--- a/src/bloqade/native/stdlib/broadcast.py
+++ b/src/bloqade/native/stdlib/broadcast.py
@@ -73,9 +73,9 @@ def phased_xz(
         qubits (ilist.IList[qubit.Qubit, Any]): Target qubits.
     """
     _phased_xz_turns(
-        2.0 * _radian_to_turn(x_rad),
-        2.0 * _radian_to_turn(z_rad),
-        2.0 * _radian_to_turn(axis_phase_rad),
+        _radian_to_turn(x_rad),
+        _radian_to_turn(z_rad),
+        _radian_to_turn(axis_phase_rad),
         qubits,
     )
 
@@ -243,7 +243,7 @@ def shift(angle: float, qubits: ilist.IList[qubit.Qubit, Any]):
         angle (float): Phase shift angle in radians.
         qubits (ilist.IList[qubit.Qubit, Any]): Target qubits.
     """
-    rz(angle / 2.0, qubits)
+    rz(angle, qubits)
 
 
 @kernel

--- a/src/bloqade/squin/gate/stmts.py
+++ b/src/bloqade/squin/gate/stmts.py
@@ -127,7 +127,6 @@ class U3(Gate):
 
 @statement(dialect=dialect)
 class PhasedXZ(Gate):
-    # NOTE: keep turns convention, matching cirq.PhasedXZGate exponents.
     traits = frozenset({lowering.FromPythonCall()})
     x_exponent: ir.SSAValue = info.argument(types.Float)
     z_exponent: ir.SSAValue = info.argument(types.Float)

--- a/src/bloqade/squin/stdlib/broadcast/gate.py
+++ b/src/bloqade/squin/stdlib/broadcast/gate.py
@@ -269,9 +269,9 @@ def phased_xz(
         qubits (ilist.IList[Qubit, Any]): Target qubits.
     """
     gate.phased_xz(
-        2.0 * _radian_to_turn(x_rad),
-        2.0 * _radian_to_turn(z_rad),
-        2.0 * _radian_to_turn(axis_phase_rad),
+        _radian_to_turn(x_rad),
+        _radian_to_turn(z_rad),
+        _radian_to_turn(axis_phase_rad),
         qubits,
     )
 
@@ -286,4 +286,4 @@ def shift(angle: float, qubits: ilist.IList[Qubit, Any]) -> None:
         angle (float): Phase shift angle in radians.
         qubits (ilist.IList[qubit.Qubit, Any]): Target qubits.
     """
-    rz(angle / 2.0, qubits)
+    rz(angle, qubits)

--- a/test/native/test_matrices.py
+++ b/test/native/test_matrices.py
@@ -45,6 +45,29 @@ def rz(theta: float) -> np.ndarray:
     )
 
 
+def cirq_phased_xz(x_rad: float, z_rad: float, axis_phase_rad: float) -> np.ndarray:
+    """PhasedXZGate matrix per cirq docs, using bloqade's radian inputs.
+
+    Cirq's docs give the matrix in exponents x, z, a (1 exponent = π rad),
+    so cirq_x_exp = x_rad / π, etc.
+    """
+    x, z, a = x_rad / math.pi, z_rad / math.pi, axis_phase_rad / math.pi
+    c, s = math.cos(math.pi * x / 2), math.sin(math.pi * x / 2)
+    return np.array(
+        [
+            [
+                np.exp(1j * math.pi * x / 2) * c,
+                -1j * np.exp(1j * math.pi * (x / 2 - a)) * s,
+            ],
+            [
+                -1j * np.exp(1j * math.pi * (x / 2 + z + a)) * s,
+                np.exp(1j * math.pi * (x / 2 + z)) * c,
+            ],
+        ],
+        dtype=complex,
+    )
+
+
 def assert_unitary_close(
     U_actual: np.ndarray, U_expected: np.ndarray, atol: float = 1e-6
 ) -> None:
@@ -187,5 +210,4 @@ def test_native_phased_xz_matrix(x_rad, z_rad, axis_phase_rad):
         native.phased_xz(x_rad, z_rad, axis_phase_rad, q[1])
 
     U = _run_and_reshape(choi, n=1)
-    expected = rz(axis_phase_rad + z_rad) @ rx(x_rad) @ rz(-axis_phase_rad)
-    assert_unitary_close(U, expected)
+    assert_unitary_close(U, cirq_phased_xz(x_rad, z_rad, axis_phase_rad))

--- a/test/native/test_matrices.py
+++ b/test/native/test_matrices.py
@@ -150,3 +150,42 @@ def test_native_2q_matrix(gate_kernel, expected):
 
     U = _run_and_reshape(choi, n=2)
     assert_unitary_close(U, expected)
+
+
+@pytest.mark.parametrize(
+    "angle", (0.0, math.pi / 4, math.pi / 2, math.pi, -math.pi / 3, 1.234)
+)
+def test_native_shift_matrix(angle):
+    @native.kernel
+    def choi():
+        q = squin.qalloc(2)
+        native.h(q[0])
+        native.cx(q[0], q[1])
+        native.shift(angle, q[1])
+
+    U = _run_and_reshape(choi, n=1)
+    # shift(angle) applies diag(1, e^{i*angle}) up to global phase, same as Rz(angle).
+    assert_unitary_close(U, rz(angle))
+
+
+@pytest.mark.parametrize(
+    "x_rad, z_rad, axis_phase_rad",
+    [
+        (math.pi / 2, 0.0, 0.0),
+        (math.pi, 0.0, 0.0),
+        (math.pi / 2, 0.0, math.pi / 4),
+        (math.pi / 3, math.pi / 5, -math.pi / 7),
+        (0.7, 1.1, -0.3),
+    ],
+)
+def test_native_phased_xz_matrix(x_rad, z_rad, axis_phase_rad):
+    @native.kernel
+    def choi():
+        q = squin.qalloc(2)
+        native.h(q[0])
+        native.cx(q[0], q[1])
+        native.phased_xz(x_rad, z_rad, axis_phase_rad, q[1])
+
+    U = _run_and_reshape(choi, n=1)
+    expected = rz(axis_phase_rad + z_rad) @ rx(x_rad) @ rz(-axis_phase_rad)
+    assert_unitary_close(U, expected)

--- a/test/native/test_stdlib.py
+++ b/test/native/test_stdlib.py
@@ -183,7 +183,8 @@ def test_phased_xz_against_squin(x_rad: float, z_rad: float, axis_phase_rad: flo
     sv_native = np.asarray(sv_native)
     sv_squin = np.asarray(sv_squin)
 
-    # Compare up to global phase. argmax-based alignment is unstable when two
-    # amplitudes tie in magnitude (argmax can pick different indices for the
-    # two simulation results), so instead check |<native|squin>| == 1.
-    assert np.isclose(abs(np.vdot(sv_native, sv_squin)), 1.0, atol=1e-6)
+    i = np.abs(sv_native).argmax()
+    sv_native *= np.exp(-1j * np.angle(sv_native[i]))
+    sv_squin *= np.exp(-1j * np.angle(sv_squin[i]))
+
+    assert np.allclose(sv_native, sv_squin, atol=1e-6)

--- a/test/native/test_stdlib.py
+++ b/test/native/test_stdlib.py
@@ -183,10 +183,7 @@ def test_phased_xz_against_squin(x_rad: float, z_rad: float, axis_phase_rad: flo
     sv_native = np.asarray(sv_native)
     sv_squin = np.asarray(sv_squin)
 
-    native_i = np.abs(sv_native).argmax()
-    sv_native *= np.exp(-1j * np.angle(sv_native[native_i]))
-
-    squin_i = np.abs(sv_squin).argmax()
-    sv_squin *= np.exp(-1j * np.angle(sv_squin[squin_i]))
-
-    assert np.allclose(sv_native, sv_squin, atol=1e-6)
+    # Compare up to global phase. argmax-based alignment is unstable when two
+    # amplitudes tie in magnitude (argmax can pick different indices for the
+    # two simulation results), so instead check |<native|squin>| == 1.
+    assert np.isclose(abs(np.vdot(sv_native, sv_squin)), 1.0, atol=1e-6)

--- a/test/squin/test_matrices.py
+++ b/test/squin/test_matrices.py
@@ -40,6 +40,29 @@ def rz(theta: float) -> np.ndarray:
     )
 
 
+def cirq_phased_xz(x_rad: float, z_rad: float, axis_phase_rad: float) -> np.ndarray:
+    """PhasedXZGate matrix per cirq docs, using bloqade's radian inputs.
+
+    Cirq's docs give the matrix in exponents x, z, a (1 exponent = π rad),
+    so cirq_x_exp = x_rad / π, etc.
+    """
+    x, z, a = x_rad / math.pi, z_rad / math.pi, axis_phase_rad / math.pi
+    c, s = math.cos(math.pi * x / 2), math.sin(math.pi * x / 2)
+    return np.array(
+        [
+            [
+                np.exp(1j * math.pi * x / 2) * c,
+                -1j * np.exp(1j * math.pi * (x / 2 - a)) * s,
+            ],
+            [
+                -1j * np.exp(1j * math.pi * (x / 2 + z + a)) * s,
+                np.exp(1j * math.pi * (x / 2 + z)) * c,
+            ],
+        ],
+        dtype=complex,
+    )
+
+
 def assert_unitary_close(
     U_actual: np.ndarray, U_expected: np.ndarray, atol: float = 1e-6
 ) -> None:
@@ -180,5 +203,4 @@ def test_squin_phased_xz_matrix(x_rad, z_rad, axis_phase_rad):
         squin.phased_xz(x_rad, z_rad, axis_phase_rad, q[1])
 
     U = _run_and_reshape(choi, n=1)
-    expected = rz(axis_phase_rad + z_rad) @ rx(x_rad) @ rz(-axis_phase_rad)
-    assert_unitary_close(U, expected)
+    assert_unitary_close(U, cirq_phased_xz(x_rad, z_rad, axis_phase_rad))

--- a/test/squin/test_matrices.py
+++ b/test/squin/test_matrices.py
@@ -144,3 +144,41 @@ def test_squin_2q_matrix(gate_kernel, expected):
 
     U = _run_and_reshape(choi, n=2)
     assert_unitary_close(U, expected)
+
+
+@pytest.mark.parametrize(
+    "angle", (0.0, math.pi / 4, math.pi / 2, math.pi, -math.pi / 3, 1.234)
+)
+def test_squin_shift_matrix(angle):
+    @squin.kernel
+    def choi():
+        q = squin.qalloc(2)
+        squin.h(q[0])
+        squin.cx(q[0], q[1])
+        squin.shift(angle, q[1])
+
+    U = _run_and_reshape(choi, n=1)
+    assert_unitary_close(U, rz(angle))
+
+
+@pytest.mark.parametrize(
+    "x_rad, z_rad, axis_phase_rad",
+    [
+        (math.pi / 2, 0.0, 0.0),
+        (math.pi, 0.0, 0.0),
+        (math.pi / 2, 0.0, math.pi / 4),
+        (math.pi / 3, math.pi / 5, -math.pi / 7),
+        (0.7, 1.1, -0.3),
+    ],
+)
+def test_squin_phased_xz_matrix(x_rad, z_rad, axis_phase_rad):
+    @squin.kernel
+    def choi():
+        q = squin.qalloc(2)
+        squin.h(q[0])
+        squin.cx(q[0], q[1])
+        squin.phased_xz(x_rad, z_rad, axis_phase_rad, q[1])
+
+    U = _run_and_reshape(choi, n=1)
+    expected = rz(axis_phase_rad + z_rad) @ rx(x_rad) @ rz(-axis_phase_rad)
+    assert_unitary_close(U, expected)


### PR DESCRIPTION
Documentation was misleading. In all cases the args were treated as turns with the exception of the stdlib implementation in the native dialect.

Separately, the `shift` gate was missing a factor of 2 in the input phase.

Added integration tests based on pyqrack.