### PR TITLE
Fix update_branched_fidelities never extending fidelity lists

### DIFF
--- a/src/bloqade/analysis/fidelity/analysis.py
+++ b/src/bloqade/analysis/fidelity/analysis.py
@@ -98,10 +98,8 @@ class FidelityAnalysis(AddressAnalysis):
     ):
         """Update fidelity (min, max) values after evaluating differing branches such as IfElse"""
         # NOTE: make sure they are all of the same length
-        map(
-            self.extend_fidelity,
-            (fidelities, current_fidelities, then_fidelities, else_fidelities),
-        )
+        for lst in (fidelities, current_fidelities, then_fidelities, else_fidelities):
+            self.extend_fidelity(lst)
 
         # NOTE: now we update min / max accordingly
         for fid, current_fid, then_fid, else_fid in zip(

--- a/test/analysis/fidelity/test_fidelity.py
+++ b/test/analysis/fidelity/test_fidelity.py
@@ -382,3 +382,22 @@ def test_squin_know_if():
         FidelityRange(1.0, 1.0),
         FidelityRange(0.8, 0.8),
     ]
+
+
+def test_update_branched_fidelities_extends_lists():
+    fa = FidelityAnalysis.__new__(FidelityAnalysis)
+    fa._next_address = 3
+    fa.gate_fidelities = []
+    fa.qubit_survival_fidelities = []
+
+    a = [FidelityRange(1.0, 1.0)]
+    b = [FidelityRange(1.0, 1.0), FidelityRange(1.0, 1.0)]
+    c = [FidelityRange(1.0, 1.0)]
+    d: list[FidelityRange] = []
+
+    fa.update_branched_fidelities(a, b, c, d)
+
+    assert len(a) == 3
+    assert len(b) == 3
+    assert len(c) == 3
+    assert len(d) == 3


### PR DESCRIPTION
`update_branched_fidelities` called `map(self.extend_fidelity, ...)` but never consumed the iterator, so the four fidelity lists were never extended to match the qubit count.

```python
from bloqade.analysis.fidelity.analysis import FidelityAnalysis, FidelityRange

fa = FidelityAnalysis.__new__(FidelityAnalysis)
fa._next_address = 3
fa.gate_fidelities = []
fa.qubit_survival_fidelities = []

a = [FidelityRange(1.0, 1.0)]
b = [FidelityRange(1.0, 1.0), FidelityRange(1.0, 1.0)]
c = [FidelityRange(1.0, 1.0)]
d = []

fa.update_branched_fidelities(a, b, c, d)
print(len(a), len(b), len(c), len(d))  # before: 1 2 1 0  -- after fix: 3 3 3 3
```

This fix was authored with Claude Code.