### PR TITLE
Fix CallGraphPass dropping dialect set on callee copies

### DIFF
--- a/src/bloqade/rewrite/passes/callgraph.py
+++ b/src/bloqade/rewrite/passes/callgraph.py
@@ -104,7 +104,7 @@ class CallGraphPass(passes.Pass):
             if original_mt is mt:
                 new_mt = original_mt
             else:
-                new_mt = original_mt.similar()
+                new_mt = original_mt.similar(self.dialects)
             result = self.rule.rewrite(new_mt.code).join(result)
             mt_map[original_mt] = new_mt
 

--- a/test/rewrite/test_callgraph.py
+++ b/test/rewrite/test_callgraph.py
@@ -1,0 +1,37 @@
+from kirin import rewrite
+from kirin.rewrite.abc import RewriteRule, RewriteResult
+from kirin.analysis.callgraph import CallGraph
+
+from bloqade import squin
+from bloqade.squin.gate import stmts as squin_gate_stmts
+from bloqade.rewrite.passes import CallGraphPass
+from bloqade.native.dialects import gate as native_gate
+
+
+class TouchHRule(RewriteRule):
+    def rewrite_Statement(self, node) -> RewriteResult:
+        if isinstance(node, squin_gate_stmts.H):
+            return RewriteResult(has_done_something=True)
+        return RewriteResult()
+
+
+def test_callgraph_pass_propagates_dialects_to_callees():
+    @squin.kernel
+    def callee():
+        q = squin.qalloc(1)
+        squin.h(q[0])
+
+    @squin.kernel
+    def caller():
+        callee()
+
+    assert native_gate not in callee.dialects
+    extended_dialects = caller.dialects.union([native_gate])
+
+    CallGraphPass(extended_dialects, rewrite.Walk(TouchHRule()))(caller)
+
+    cg = CallGraph(caller)
+    new_callees = [m for m in cg.edges.keys() if m is not caller]
+    assert new_callees, "expected at least one callee in the callgraph"
+    for ker in new_callees:
+        assert native_gate in ker.dialects

--- a/test/rewrite/test_callgraph.py
+++ b/test/rewrite/test_callgraph.py
@@ -3,23 +3,29 @@ from kirin.rewrite.abc import RewriteRule, RewriteResult
 from kirin.analysis.callgraph import CallGraph
 
 from bloqade import squin
-from bloqade.squin.gate import stmts as squin_gate_stmts
 from bloqade.rewrite.passes import CallGraphPass
 from bloqade.native.dialects import gate as native_gate
 
 
-class TouchHRule(RewriteRule):
+class _AlwaysReportsChange(RewriteRule):
+    # CallGraphPass only commits its callee replacements into the caller
+    # when the rule reports a change. Without that commit step, a
+    # CallGraph lookup on the caller after the pass still resolves to
+    # the original (uncopied) callees, making any dialect check below
+    # vacuous. This rule signals a change without actually mutating the IR.
     def rewrite_Statement(self, node) -> RewriteResult:
-        if isinstance(node, squin_gate_stmts.H):
-            return RewriteResult(has_done_something=True)
-        return RewriteResult()
+        return RewriteResult(has_done_something=True)
 
 
-def test_callgraph_pass_propagates_dialects_to_callees():
+def test_callgraph_pass_propagates_dialects_to_callee_copies():
+    # Regression: CallGraphPass must forward its dialect set to
+    # `similar()` when copying callees. Otherwise callee copies keep
+    # their original (narrower) dialect group and rewrites targeting
+    # the extended dialects silently fail to apply inside callees.
     @squin.kernel
     def callee():
         q = squin.qalloc(1)
-        squin.h(q[0])
+        return q
 
     @squin.kernel
     def caller():
@@ -28,10 +34,12 @@ def test_callgraph_pass_propagates_dialects_to_callees():
     assert native_gate not in callee.dialects
     extended_dialects = caller.dialects.union([native_gate])
 
-    CallGraphPass(extended_dialects, rewrite.Walk(TouchHRule()))(caller)
+    CallGraphPass(extended_dialects, rewrite.Walk(_AlwaysReportsChange()))(caller)
 
-    cg = CallGraph(caller)
-    new_callees = [m for m in cg.edges.keys() if m is not caller]
-    assert new_callees, "expected at least one callee in the callgraph"
+    new_callees = [m for m in CallGraph(caller).edges.keys() if m is not caller]
+    assert new_callees, "expected the callee in the post-rewrite callgraph"
     for ker in new_callees:
-        assert native_gate in ker.dialects
+        assert native_gate in ker.dialects, (
+            "callee copies should inherit the extended dialect set "
+            "passed to CallGraphPass"
+        )


### PR DESCRIPTION
`CallGraphPass.unsafe_run` called `original_mt.similar()` without passing `self.dialects`, so callee copies kept their original dialect group instead of the combined one. Rewrites that depended on the new dialects (e.g. `SquinToNative`'s `GateRule`) silently failed to apply inside callee kernels. The sibling `UpdateDialectsOnCallGraph.unsafe_run` already passes `self.dialects`; this aligns the two.

```python
import inspect
from bloqade.rewrite.passes.callgraph import CallGraphPass, UpdateDialectsOnCallGraph

print("similar(self.dialects)" in inspect.getsource(UpdateDialectsOnCallGraph.unsafe_run))  # True
print("similar(self.dialects)" in inspect.getsource(CallGraphPass.unsafe_run))              # before: False, after: True
```

This fix was authored with Claude Code.