### PR TITLE
Remove duplicated cases in SimpleMergePolicy.can_merge

### DIFF
--- a/src/bloqade/qasm2/rewrite/uop_to_parallel.py
+++ b/src/bloqade/qasm2/rewrite/uop_to_parallel.py
@@ -93,8 +93,6 @@ class SimpleMergePolicy(MergePolicyABC):
                 | (parallel.UGate(), parallel.UGate())
                 | (parallel.UGate(), uop.UGate())
                 | (uop.UGate(), parallel.UGate())
-                | (uop.UGate(), parallel.UGate())
-                | (uop.UGate(), parallel.UGate())
                 | (parallel.RZ(), parallel.RZ())
                 | (uop.RZ(), parallel.RZ())
                 | (parallel.RZ(), uop.RZ())


### PR DESCRIPTION
The match pattern in `SimpleMergePolicy.can_merge` listed `(uop.UGate(), parallel.UGate())` three times. Behavior is unchanged — match patterns OR'd with duplicates collapse — but the duplicates are dead code and a maintenance smell.

This fix was authored with Claude Code.