### PR TITLE
feat: added Register to bloqade.types

### DIFF
--- a/src/bloqade/types.py
+++ b/src/bloqade/types.py
@@ -4,8 +4,10 @@ This module defines the basic types used in Bloqade eDSLs.
 """
 
 from abc import ABC
+from typing import Any
 
 from kirin import types
+from kirin.dialects.ilist import IList
 
 from bloqade.decoders.dialects.annotate.types import (
     MeasurementResult as MeasurementResult,
@@ -24,6 +26,9 @@ class Qubit(ABC):
 
     pass
 
+
+Register = IList[Qubit, Any]
+"""Runtime representation of a qubit register."""
 
 QubitType = types.PyClass(Qubit)
 """Kirin type for a qubit."""


### PR DESCRIPTION
## Summary

Closes #450.

Adds `Register` to `bloqade.types` as a convenience alias for qubit registers:

```python
Register = IList[Qubit, Any]
```

## Changes

- Import `Any` from `typing`
- Import `IList` from `kirin.dialects.ilist`
- Add `Register` alongside the existing `Qubit` type definitions

## Verification

Ran an import smoke test:

```sh
uv run --no-sync python -c "from bloqade.types import Register, Qubit; from typing import Any; from kirin.dialects.ilist import IList; assert Register == IList[Qubit, Any]"
```
