### PR TITLE
fix: allow tsim.Circuit and stim.Circuit init from program string

### DIFF
--- a/src/bloqade/stim/circuit.py
+++ b/src/bloqade/stim/circuit.py
@@ -34,16 +34,22 @@ def _codegen(mt: ir.Method) -> str:
 
 
 class Circuit(_Circuit):
-    def __init__(self, kernel: ir.Method):
-        """Initialize stim.Circuit from a kernel.
+    """A `stim.Circuit` that can be built from a squin kernel or a program string."""
+
+    def __init__(self, kernel: ir.Method | str, *args, **kwargs):
+        """Initialize stim.Circuit from a kernel or a STIM program string.
 
         This class inherits from `stim.Circuit`. For the full API reference of
         the underlying circuit class, see:
         https://github.com/quantumlib/Stim/blob/main/doc/python_api_reference_vDev.md#stim.Circuit
 
         Args:
-            kernel: The kernel to compile into a stim.Circuit.
+            kernel: The kernel to compile into a stim.Circuit, or a STIM program
+                string to pass directly to the underlying circuit.
+            *args: Additional positional arguments forwarded to `stim.Circuit`.
+            **kwargs: Additional keyword arguments forwarded to `stim.Circuit`.
 
         """
-        program_text = _codegen(kernel)
-        super().__init__(program_text)
+        if isinstance(kernel, ir.Method):
+            kernel = _codegen(kernel)
+        super().__init__(kernel, *args, **kwargs)

--- a/src/bloqade/tsim/circuit.py
+++ b/src/bloqade/tsim/circuit.py
@@ -19,16 +19,22 @@ except ImportError:
 
 
 class Circuit(_Circuit):
-    def __init__(self, kernel: ir.Method):
-        """Initialize tsim.Circuit from a kernel.
+    """A `tsim.Circuit` that can be built from a squin kernel or a program string."""
+
+    def __init__(self, kernel: ir.Method | str, *args, **kwargs):
+        """Initialize tsim.Circuit from a kernel or a STIM program string.
 
         This class inherits from `tsim.Circuit`. For the full API reference of
         the underlying circuit class, see:
         https://queracomputing.github.io/tsim/latest/reference/tsim/circuit/
 
         Args:
-            kernel: The kernel to compile into a tsim.Circuit.
+            kernel: The kernel to compile into a tsim.Circuit, or a STIM program
+                string to pass directly to the underlying circuit.
+            *args: Additional positional arguments forwarded to `tsim.Circuit`.
+            **kwargs: Additional keyword arguments forwarded to `tsim.Circuit`.
 
         """
-        program_text = _codegen(kernel)
-        super().__init__(program_text)
+        if isinstance(kernel, ir.Method):
+            kernel = _codegen(kernel)
+        super().__init__(kernel, *args, **kwargs)

--- a/test/stim/test_circuit.py
+++ b/test/stim/test_circuit.py
@@ -5,6 +5,8 @@ from bloqade.squin import kernel
 
 
 def test_circuit():
+    """Build a stim.Circuit from a squin kernel."""
+
     @kernel
     def main():
         q = squin.qalloc(2)
@@ -14,3 +16,19 @@ def test_circuit():
     circuit = Circuit(main)
     assert isinstance(circuit, stim.Circuit)
     assert str(circuit) == "H 0\nCX 0 1"
+
+
+def test_circuit_from_string():
+    """Build a stim.Circuit directly from a STIM program string."""
+    program_text = "H 0\nCX 0 1"
+
+    circuit = Circuit(program_text)
+    assert isinstance(circuit, stim.Circuit)
+    assert str(circuit) == program_text
+
+
+def test_circuit_from_string_matches_native():
+    """A string-initialized Circuit matches the native stim.Circuit."""
+    program_text = "H 0\nCX 0 1"
+
+    assert str(Circuit(program_text)) == str(stim.Circuit(program_text))

--- a/test/tsim/test_circuit.py
+++ b/test/tsim/test_circuit.py
@@ -5,6 +5,8 @@ from bloqade.squin import kernel
 
 
 def test_circuit():
+    """Build a tsim.Circuit from a squin kernel."""
+
     @kernel
     def main():
         q = squin.qalloc(2)
@@ -15,3 +17,19 @@ def test_circuit():
     circuit = Circuit(main)
     assert isinstance(circuit, tsim.Circuit)
     assert str(circuit) == "H 0\nT 0\nCX 0 1"
+
+
+def test_circuit_from_string():
+    """Build a tsim.Circuit directly from a STIM program string."""
+    program_text = "H 0\nT 0\nCX 0 1"
+
+    circuit = Circuit(program_text)
+    assert isinstance(circuit, tsim.Circuit)
+    assert str(circuit) == program_text
+
+
+def test_circuit_from_string_matches_native():
+    """A string-initialized Circuit matches the native tsim.Circuit."""
+    program_text = "H 0\nT 0\nCX 0 1"
+
+    assert str(Circuit(program_text)) == str(tsim.Circuit(program_text))


### PR DESCRIPTION
## Summary

Fixes #768.

`bloqade.tsim.Circuit` and `bloqade.stim.Circuit` only accepted an `ir.Method` kernel and unconditionally ran `_codegen`, which calls `kernel.similar()`. Passing a STIM program string — which the bare `tsim`/`stim` packages accept directly — raised:

```
AttributeError: 'str' object has no attribute 'similar'
```

This made `from bloqade import tsim; tsim.Circuit("R 0")` behave differently from `import tsim; tsim.Circuit("R 0")`.

## Change

Both `Circuit.__init__` methods now accept either a kernel or a string:

- An `ir.Method` is compiled to program text via `_codegen` (unchanged behavior).
- A `str` (plus any extra positional/keyword args) is forwarded straight to the underlying `tsim.Circuit` / `stim.Circuit` constructor.

The same bug existed in both `tsim` and `stim` wrappers, so both are fixed.

## Tests

Added tests for string initialization to `test/tsim/test_circuit.py` and `test/stim/test_circuit.py`, verifying the string-built circuit matches the native circuit. Developed test-first (confirmed the new tests reproduce the reported `AttributeError` before the fix). Full `test/tsim` and `test/stim` suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)