### PR TITLE
feat: restore address analysis rewrite

### DIFF
--- a/src/bloqade/squin/rewrite/__init__.py
+++ b/src/bloqade/squin/rewrite/__init__.py
@@ -1,1 +1,8 @@
+"""Rewrite helpers for Squin programs."""
+
+from .wrap_analysis import (
+    WrapAnalysis as WrapAnalysis,
+    AddressAttribute as AddressAttribute,
+    WrapAddressAnalysis as WrapAddressAnalysis,
+)
 from .U3_to_clifford import SquinU3ToClifford as SquinU3ToClifford

--- a/src/bloqade/squin/rewrite/wrap_analysis.py
+++ b/src/bloqade/squin/rewrite/wrap_analysis.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from abc import abstractmethod
+from dataclasses import dataclass
+
+from kirin import ir
+from kirin.rewrite.abc import RewriteRule, RewriteResult
+from kirin.print.printer import Printer
+
+from bloqade import qubit
+from bloqade.analysis.address import Address
+
+
+@qubit.dialect.register
+@dataclass
+class AddressAttribute(ir.Attribute):
+    """IR attribute carrying an address-analysis result."""
+
+    name = "Address"
+
+    address: Address
+
+    def __hash__(self) -> int:
+        """Return a hash based on the wrapped address."""
+
+        return hash(self.address)
+
+    def print_impl(self, printer: Printer) -> None:
+        """Print the wrapped address."""
+
+        printer.print(self.address)
+
+
+@dataclass
+class WrapAnalysis(RewriteRule):
+    """Base rewrite rule that wraps analysis data onto SSA values."""
+
+    @abstractmethod
+    def wrap(self, value: ir.SSAValue) -> bool:
+        """Wrap one SSA value and report whether it changed."""
+
+        return False
+
+    def rewrite_Block(self, node: ir.Block) -> RewriteResult:
+        """Wrap block arguments."""
+
+        has_done_something = any(self.wrap(arg) for arg in node.args)
+        return RewriteResult(has_done_something=has_done_something)
+
+    def rewrite_Statement(self, node: ir.Statement) -> RewriteResult:
+        """Wrap statement results."""
+
+        has_done_something = any(self.wrap(result) for result in node.results)
+        return RewriteResult(has_done_something=has_done_something)
+
+
+@dataclass
+class WrapAddressAnalysis(WrapAnalysis):
+    """Wrap address-analysis results into SSA value hints."""
+
+    address_analysis: dict[ir.SSAValue, Address]
+
+    def wrap(self, value: ir.SSAValue) -> bool:
+        """Attach an address hint to a value when analysis produced one."""
+
+        address_analysis_result = self.address_analysis.get(value)
+        if address_analysis_result is None:
+            return False
+
+        if value.hints.get("address") is not None:
+            return False
+
+        value.hints["address"] = AddressAttribute(address_analysis_result)
+        return True

--- a/src/bloqade/squin/rewrite/wrap_analysis.py
+++ b/src/bloqade/squin/rewrite/wrap_analysis.py
@@ -23,7 +23,7 @@ class AddressAttribute(ir.Attribute):
     def __hash__(self) -> int:
         """Return a hash based on the wrapped address."""
 
-        return hash(self.address)
+        return hash((type(self.address), repr(self.address)))
 
     def print_impl(self, printer: Printer) -> None:
         """Print the wrapped address."""

--- a/test/squin/rewrite/test_wrap_analysis.py
+++ b/test/squin/rewrite/test_wrap_analysis.py
@@ -1,0 +1,96 @@
+from kirin import ir, types
+
+from bloqade.analysis import address
+from bloqade.squin.rewrite.wrap_analysis import (
+    WrapAnalysis,
+    AddressAttribute,
+    WrapAddressAnalysis,
+)
+
+
+class _TestStmt(ir.Statement):
+    name = "test.stmt"
+
+
+class DelegatingWrapAnalysis(WrapAnalysis):
+    def wrap(self, value: ir.SSAValue) -> bool:
+        return super().wrap(value)
+
+
+class RecordingWrapAnalysis(WrapAnalysis):
+    def __init__(self, wrapped_values: set[ir.SSAValue]):
+        self.wrapped_values = wrapped_values
+        self.seen_values: list[ir.SSAValue] = []
+
+    def wrap(self, value: ir.SSAValue) -> bool:
+        self.seen_values.append(value)
+        return value in self.wrapped_values
+
+
+def test_address_attribute_hashes_and_prints_wrapped_address():
+    addr = address.AddressQubit(1)
+    attribute = AddressAttribute(addr)
+    printed_values = []
+
+    class Printer:
+        def print(self, value):
+            printed_values.append(value)
+
+    assert hash(attribute) == hash((type(addr), repr(addr)))
+
+    attribute.print_impl(Printer())
+
+    assert printed_values == [addr]
+
+
+def test_wrap_analysis_default_wrap_does_not_change_value():
+    value = ir.TestValue(type=types.Int)
+
+    assert DelegatingWrapAnalysis().wrap(value) is False
+
+
+def test_wrap_analysis_wraps_block_arguments():
+    block = ir.Block(argtypes=[types.Int, types.Int])
+    rule = RecordingWrapAnalysis({block.args[1]})
+
+    result = rule.rewrite_Block(block)
+
+    assert result.has_done_something is True
+    assert rule.seen_values == list(block.args)
+
+
+def test_wrap_analysis_wraps_statement_results():
+    statement = _TestStmt(result_types=[types.Int, types.Int])
+    rule = RecordingWrapAnalysis({statement.results[1]})
+
+    result = rule.rewrite_Statement(statement)
+
+    assert result.has_done_something is True
+    assert rule.seen_values == list(statement.results)
+
+
+def test_wrap_address_analysis_ignores_values_without_address_results():
+    value = ir.TestValue(type=types.Int)
+    rule = WrapAddressAnalysis({})
+
+    assert rule.wrap(value) is False
+    assert "address" not in value.hints
+
+
+def test_wrap_address_analysis_ignores_existing_address_hints():
+    value = ir.TestValue(type=types.Int)
+    existing_attribute = AddressAttribute(address.AddressQubit(0))
+    value.hints["address"] = existing_attribute
+    rule = WrapAddressAnalysis({value: address.AddressQubit(1)})
+
+    assert rule.wrap(value) is False
+    assert value.hints["address"] is existing_attribute
+
+
+def test_wrap_address_analysis_attaches_address_hint():
+    value = ir.TestValue(type=types.Int)
+    addr = address.AddressQubit(2)
+    rule = WrapAddressAnalysis({value: addr})
+
+    assert rule.wrap(value) is True
+    assert value.hints["address"] == AddressAttribute(addr)


### PR DESCRIPTION
## Dependencies

Same-repo stack:
- Depends on: none; base is `main`.
- This PR is base for: `codex-msd-circuit-tomography`.

Cross-repo dependencies:
- Depends on: none.
- Required for CI: no.

Review status:
- Draft until dependencies are merged/released: no.

## Summary

- Restores and exports `WrapAddressAnalysis` under `bloqade.squin.rewrite`.
- Supports downstream logical-kernel construction in lanes.

## Review focus

- Rewriter placement and public export behavior.
- Address-analysis wrapping behavior.

## Test plan

- `uv run --index-strategy=unsafe-best-match pytest test/analysis/tomography/test_tomography.py -q` -> `4 passed in 0.45s` on full circuit stack.
- `uv run --index-strategy=unsafe-best-match ruff check src/bloqade/analysis/tomography src/bloqade/squin/rewrite test/analysis/tomography/test_tomography.py` -> passed.