### PR TITLE
feat(squin): add Clifford validation pass

### DIFF
--- a/src/bloqade/squin/analysis/validation/__init__.py
+++ b/src/bloqade/squin/analysis/validation/__init__.py
@@ -1,0 +1,1 @@
+from .clifford import CliffordValidation as CliffordValidation

--- a/src/bloqade/squin/analysis/validation/clifford/__init__.py
+++ b/src/bloqade/squin/analysis/validation/clifford/__init__.py
@@ -1,0 +1,1 @@
+from .validation import CliffordValidation as CliffordValidation

--- a/src/bloqade/squin/analysis/validation/clifford/validation.py
+++ b/src/bloqade/squin/analysis/validation/clifford/validation.py
@@ -1,0 +1,96 @@
+import math
+from typing import Any
+
+from kirin import ir
+from kirin.validation import ValidationPass
+
+from bloqade.squin import gate
+from bloqade.squin.rewrite.U3_to_clifford import (
+    RX_HALF_PI_TO_CLIFFORD,
+    RY_HALF_PI_TO_CLIFFORD,
+    RZ_HALF_PI_TO_CLIFFORD,
+    SquinU3ToClifford,
+)
+
+_CLIFFORD_GATES = (
+    gate.stmts.X,
+    gate.stmts.Y,
+    gate.stmts.Z,
+    gate.stmts.H,
+    gate.stmts.S,
+    gate.stmts.SqrtX,
+    gate.stmts.SqrtY,
+    gate.stmts.CX,
+    gate.stmts.CY,
+    gate.stmts.CZ,
+)
+
+
+class CliffordValidation(ValidationPass):
+    """Validate that a Squin kernel contains only Clifford gates."""
+
+    def name(self) -> str:
+        return "Clifford Validation"
+
+    def _add_non_clifford_error(
+        self,
+        stmt: ir.Statement,
+        errors: list[ir.ValidationError],
+    ) -> None:
+        errors.append(
+            ir.ValidationError(
+                stmt,
+                f"Non-Clifford gate {type(stmt).__name__} is not allowed "
+                "in Clifford-only Squin kernels.",
+            )
+        )
+
+    @staticmethod
+    def _is_clifford_rotation(stmt: gate.stmts.RotationGate) -> bool:
+        rewrite = SquinU3ToClifford()
+        if isinstance(stmt, gate.stmts.Rx):
+            clifford_map = RX_HALF_PI_TO_CLIFFORD
+        elif isinstance(stmt, gate.stmts.Ry):
+            clifford_map = RY_HALF_PI_TO_CLIFFORD
+        elif isinstance(stmt, gate.stmts.Rz):
+            clifford_map = RZ_HALF_PI_TO_CLIFFORD
+        else:
+            return False
+
+        angle = rewrite.get_constant(stmt.angle)
+        if angle is None:
+            return False
+
+        angle_half_pi = rewrite.resolve_angle(angle * math.tau)
+        return angle_half_pi is not None and angle_half_pi in clifford_map
+
+    @staticmethod
+    def _is_clifford_u3(stmt: gate.stmts.U3) -> bool:
+        return len(SquinU3ToClifford().decompose_U3_gates(stmt)) > 0
+
+    @staticmethod
+    def _is_gate_statement(stmt: ir.Statement) -> bool:
+        return isinstance(stmt, gate.stmts.Gate)
+
+    def _is_clifford_gate(self, stmt: ir.Statement) -> bool:
+        if isinstance(stmt, _CLIFFORD_GATES):
+            return True
+
+        if isinstance(stmt, gate.stmts.RotationGate):
+            return self._is_clifford_rotation(stmt)
+
+        if isinstance(stmt, gate.stmts.U3):
+            return self._is_clifford_u3(stmt)
+
+        return False
+
+    def run(self, method: ir.Method) -> tuple[Any, list[ir.ValidationError]]:
+        errors: list[ir.ValidationError] = []
+        for stmt in method.callable_region.walk():
+            if not self._is_gate_statement(stmt):
+                continue
+
+            if not self._is_clifford_gate(stmt):
+                self._add_non_clifford_error(stmt, errors)
+
+        return None, errors

--- a/test/squin/validation/test_clifford.py
+++ b/test/squin/validation/test_clifford.py
@@ -1,0 +1,84 @@
+import math
+
+import pytest
+from kirin.ir.exception import ValidationErrorGroup
+from kirin.validation import ValidationSuite
+
+from bloqade import squin
+from bloqade.rewrite.passes import AggressiveUnroll
+from bloqade.squin.analysis.validation import CliffordValidation
+
+
+def test_clifford_kernel_validates():
+    @squin.kernel
+    def main_clifford():
+        q = squin.qalloc(4)
+        squin.h(q[0])
+        squin.s(q[1])
+        squin.sqrt_x(q[2])
+        squin.cx(q[0], q[1])
+        squin.cy(q[1], q[2])
+        squin.cz(q[2], q[3])
+
+    AggressiveUnroll(main_clifford.dialects).fixpoint(main_clifford)
+
+    _, errors = CliffordValidation().run(main_clifford)
+    assert len(errors) == 0
+
+
+def test_non_clifford_t_gate_is_rejected():
+    @squin.kernel
+    def main_nonclifford():
+        q = squin.qalloc(2)
+        squin.h(q[0])
+        squin.t(q[1])
+
+    AggressiveUnroll(main_nonclifford.dialects).fixpoint(main_nonclifford)
+
+    validation_suite = ValidationSuite([CliffordValidation])
+    result = validation_suite.validate(main_nonclifford)
+    assert result.error_count() == 1
+
+    with pytest.raises(ValidationErrorGroup):
+        result.raise_if_invalid()
+
+
+def test_non_clifford_rotation_is_rejected():
+    @squin.kernel
+    def main_nonclifford():
+        q = squin.qalloc(1)
+        squin.rx(0.3 * math.pi, q[0])
+
+    AggressiveUnroll(main_nonclifford.dialects).fixpoint(main_nonclifford)
+
+    _, errors = CliffordValidation().run(main_nonclifford)
+    assert len(errors) == 1
+    assert "Rx" in str(errors[0])
+
+
+def test_clifford_rotations_are_allowed():
+    @squin.kernel
+    def main_clifford():
+        q = squin.qalloc(3)
+        squin.rx(math.pi / 2, q[0])
+        squin.ry(math.pi, q[1])
+        squin.rz(3 * math.pi / 2, q[2])
+
+    AggressiveUnroll(main_clifford.dialects).fixpoint(main_clifford)
+
+    _, errors = CliffordValidation().run(main_clifford)
+    assert len(errors) == 0
+
+
+def test_clifford_u3_is_allowed_and_non_clifford_u3_is_rejected():
+    @squin.kernel
+    def main():
+        q = squin.qalloc(2)
+        squin.u3(0.25 * math.tau, 0.0, 0.5 * math.tau, q[0])
+        squin.u3(0.3 * math.pi, 0.24 * math.pi, 0.49 * math.pi, q[1])
+
+    AggressiveUnroll(main.dialects).fixpoint(main)
+
+    _, errors = CliffordValidation().run(main)
+    assert len(errors) == 1
+    assert "U3" in str(errors[0])


### PR DESCRIPTION
Summary
- Adds `CliffordValidation` for Squin kernels
- Allows fixed Clifford gates plus constant Clifford-equivalent Rx/Ry/Rz and U3 gates
- Rejects non-Clifford gates such as T, arbitrary rotations, arbitrary U3, and PhasedXZ
- Exports the pass from `bloqade.squin.analysis.validation`

Verification
- `.venv/bin/python -m pytest test/squin/validation/test_simple_nocloning.py test/squin/validation/test_clifford.py -q -vv`
- `.venv/bin/ruff check src/bloqade/squin/analysis/validation/clifford src/bloqade/squin/analysis/validation/__init__.py test/squin/validation/test_clifford.py`
- `.venv/bin/ruff check --select I src/bloqade/squin/analysis/validation/clifford src/bloqade/squin/analysis/validation/__init__.py test/squin/validation/test_clifford.py`

AI assistance
- Prepared with OpenAI Codex assistance; I reviewed the implementation and ran the verification commands above.

Closes #665