### PR TITLE
feat: support ignored targets in annotate

### DIFF
--- a/src/bloqade/cirq_utils/emit/__init__.py
+++ b/src/bloqade/cirq_utils/emit/__init__.py
@@ -1,3 +1,3 @@
 # NOTE: just to register methods
-from . import gate as gate, noise as noise, qubit as qubit
+from . import annotate as annotate, gate as gate, noise as noise, qubit as qubit
 from .base import emit_circuit as emit_circuit

--- a/src/bloqade/cirq_utils/emit/annotate.py
+++ b/src/bloqade/cirq_utils/emit/annotate.py
@@ -1,0 +1,18 @@
+from kirin.interp import MethodTable, impl
+
+from bloqade.decoders.dialects import annotate
+
+from .base import EmitCirq, EmitCirqFrame
+
+
+@annotate.dialect.register(key="emit.cirq")
+class EmitCirqAnnotateMethods(MethodTable):
+    @impl(annotate.stmts.SetDetector)
+    @impl(annotate.stmts.SetObservable)
+    def ignore_annotation(
+        self,
+        emit: EmitCirq,
+        frame: EmitCirqFrame,
+        stmt: annotate.stmts.SetDetector | annotate.stmts.SetObservable,
+    ):
+        return (emit.void,)

--- a/src/bloqade/cirq_utils/emit/base.py
+++ b/src/bloqade/cirq_utils/emit/base.py
@@ -225,9 +225,14 @@ class __FuncEmit(MethodTable):
 class __Concrete(interp.MethodTable):
 
     @interp.impl(py.indexing.GetItem)
-    def getindex(self, interp, frame: interp.Frame, stmt: py.indexing.GetItem):
-        # NOTE: no support for indexing into single statements in cirq
-        return ()
+    def getindex(self, emit: EmitCirq, frame: interp.Frame, stmt: py.indexing.GetItem):
+        obj = frame.get(stmt.obj)
+        index = frame.get(stmt.index)
+
+        if isinstance(obj, (tuple, list, ilist.IList)):
+            return (obj[index],)
+
+        return (emit.void,)
 
     @interp.impl(py.Constant)
     def emit_constant(self, emit: EmitCirq, frame: EmitCirqFrame, stmt: py.Constant):

--- a/src/bloqade/pyqrack/__init__.py
+++ b/src/bloqade/pyqrack/__init__.py
@@ -15,7 +15,7 @@ from .task import PyQrackSimulatorTask as PyQrackSimulatorTask
 # NOTE: The following import is for registering the method tables
 from .noise import native as native
 from .qasm2 import uop as uop, core as core, glob as glob, parallel as parallel
-from .squin import gate as gate, noise as noise, qubit as qubit
+from .squin import annotate as annotate, gate as gate, noise as noise, qubit as qubit
 from .device import (
     StackMemorySimulator as StackMemorySimulator,
     DynamicMemorySimulator as DynamicMemorySimulator,

--- a/src/bloqade/pyqrack/squin/annotate.py
+++ b/src/bloqade/pyqrack/squin/annotate.py
@@ -1,0 +1,17 @@
+from kirin import interp
+
+from bloqade.decoders.dialects import annotate
+from bloqade.pyqrack.base import PyQrackInterpreter
+
+
+@annotate.dialect.register(key="pyqrack")
+class PyQrackAnnotateMethods(interp.MethodTable):
+    @interp.impl(annotate.stmts.SetDetector)
+    @interp.impl(annotate.stmts.SetObservable)
+    def ignore_annotation(
+        self,
+        interp_: PyQrackInterpreter,
+        frame: interp.Frame,
+        stmt: annotate.stmts.SetDetector | annotate.stmts.SetObservable,
+    ):
+        return (None,)

--- a/test/test_annotate_targets.py
+++ b/test/test_annotate_targets.py
@@ -1,0 +1,29 @@
+import cirq
+
+from bloqade.pyqrack import MeasurementResultValue
+from bloqade import squin
+from bloqade.cirq_utils import emit_circuit
+from bloqade.pyqrack import StackMemorySimulator
+
+
+@squin.kernel
+def annotated_kernel():
+    q = squin.qalloc(2)
+    squin.x(q[1])
+    m = squin.broadcast.measure(q)
+    squin.set_detector([m[0]], coordinates=(0, 0))
+    squin.set_observable([m[0]])
+    return m[1]
+
+
+def test_cirq_emitter_ignores_annotations():
+    circuit = emit_circuit(annotated_kernel, ignore_returns=True)
+    q = cirq.LineQubit.range(2)
+
+    assert circuit == cirq.Circuit(cirq.X(q[1]), cirq.measure(*q))
+
+
+def test_pyqrack_simulator_ignores_annotations():
+    result = StackMemorySimulator(min_qubits=2).run(annotated_kernel)
+
+    assert result == MeasurementResultValue.One


### PR DESCRIPTION
Closes #628.

## Summary

- Added no-op annotate handlers for Cirq emission and PyQrack execution so `SetDetector` / `SetObservable` statements do not block non-Stim targets.
- Taught the Cirq emitter to resolve concrete `IList` / sequence indexing used while building annotation measurement lists.
- Added a focused regression kernel that emits successfully to Cirq and runs through PyQrack while ignoring annotations.

## Validation

- `PYTHONPATH=src /Users/huahah/Documents/自主挣钱/work/bloqade-circuit/.venv/bin/python -m pytest test/test_annotate_targets.py -q`
- `PYTHONPATH=src /Users/huahah/Documents/自主挣钱/work/bloqade-circuit/.venv/bin/python -m pytest test/test_annotate.py test/test_annotate_targets.py test/cirq_utils/test_clifford_to_cirq.py test/pyqrack/squin/test_kernel.py -q`
- `PYTHONPATH=src /Users/huahah/Documents/自主挣钱/work/bloqade-circuit/.venv/bin/python -m compileall -q src/bloqade/cirq_utils src/bloqade/pyqrack test/test_annotate_targets.py`
- `PYTHONPATH=src /Users/huahah/Documents/自主挣钱/work/bloqade-circuit/.venv/bin/python -m ruff check src/bloqade/cirq_utils/emit/__init__.py src/bloqade/cirq_utils/emit/base.py src/bloqade/cirq_utils/emit/annotate.py src/bloqade/pyqrack/__init__.py src/bloqade/pyqrack/squin/annotate.py test/test_annotate_targets.py`
- `git diff --check`

## AI Assistance Disclosure

This contribution was implemented with OpenAI Codex assistance. I reviewed the generated changes and ran the validation above locally.
