### PR TITLE
feat: add PyQrack statevector histogram

### DIFF
--- a/src/bloqade/pyqrack/device.py
+++ b/src/bloqade/pyqrack/device.py
@@ -209,6 +209,16 @@ class PyQrackSimulatorBase(AbstractSimulatorDevice[PyQrackSimulatorTask]):
         """Runs task and returns the state vector."""
         return self.task(kernel, args, kwargs).state_vector()
 
+    def histogram(
+        self,
+        kernel: ir.Method[Params, RetType],
+        args: tuple[Any, ...] = (),
+        kwargs: dict[str, Any] | None = None,
+        tol: float = 1e-12,
+    ) -> dict[str, float]:
+        """Runs task and returns exact computational-basis probabilities."""
+        return self.task(kernel, args, kwargs).histogram(tol)
+
     @staticmethod
     def pauli_expectation(pauli: list[Pauli], qubits: list[PyQrackQubit]) -> float:
         """Returns the expectation value of the given Pauli operator given a list of Pauli operators and qubits.

--- a/src/bloqade/pyqrack/task.py
+++ b/src/bloqade/pyqrack/task.py
@@ -40,6 +40,28 @@ class PyQrackSimulatorTask(AbstractSimulatorTask[Param, RetType, MemoryType]):
         self.run()
         return self.state.sim_reg.out_ket()
 
+    def histogram(self, tol: float = 1e-12) -> dict[str, float]:
+        """Returns exact computational-basis probabilities from the state vector."""
+        state_vector = np.asarray(self.state_vector(), dtype=np.complex128)
+        if state_vector.ndim != 1:
+            raise ValueError("State vector must be one-dimensional.")
+
+        size = state_vector.size
+        num_qubits = int(np.log2(size))
+        if 2**num_qubits != size:
+            raise ValueError("State vector length must be a power of two.")
+
+        probabilities = np.abs(state_vector) ** 2
+        total = probabilities.sum()
+        if total != 0:
+            probabilities = probabilities / total
+
+        return {
+            format(index, f"0{num_qubits}b"): float(probability)
+            for index, probability in enumerate(probabilities)
+            if probability > tol
+        }
+
     def qubits(self) -> list[PyQrackQubit]:
         """Returns the qubits in the simulator."""
         try:

--- a/test/pyqrack/runtime/test_qrack.py
+++ b/test/pyqrack/runtime/test_qrack.py
@@ -397,6 +397,33 @@ def test_batch_run_IList_converter():
     assert len(set(results.keys()).symmetric_difference({(False,), (True,)})) == 0
 
 
+def test_histogram_bell_state():
+    @squin.kernel
+    def bell():
+        q = squin.qalloc(2)
+        squin.h(q[0])
+        squin.cx(q[0], q[1])
+
+    emulator = StackMemorySimulator(min_qubits=2)
+    histogram = emulator.task(bell).histogram()
+
+    assert set(histogram) == {"00", "11"}
+    assert np.isclose(histogram["00"], 0.5)
+    assert np.isclose(histogram["11"], 0.5)
+    assert np.isclose(sum(histogram.values()), 1.0)
+
+
+def test_device_histogram_filters_zero_probabilities():
+    @squin.kernel
+    def one():
+        q = squin.qalloc(1)
+        squin.x(q[0])
+
+    histogram = StackMemorySimulator(min_qubits=1).histogram(one)
+
+    assert histogram == {"1": 1.0}
+
+
 def test_batch_state1():
     """
     Averaging with no selector function


### PR DESCRIPTION
Closes #300.

## Summary

- Added `PyQrackSimulatorTask.histogram()` to derive exact computational-basis probabilities from the simulator state vector.
- Added `PyQrackSimulatorBase.histogram()` as the device-level convenience wrapper.
- Added focused PyQrack runtime tests for a Bell-state histogram and zero-probability filtering.

## Validation

- `PYTHONPATH=src /Users/huahah/Documents/自主挣钱/work/bloqade-circuit/.venv/bin/python -m pytest test/pyqrack/runtime/test_qrack.py -q`
- `PYTHONPATH=src /Users/huahah/Documents/自主挣钱/work/bloqade-circuit/.venv/bin/python -m compileall -q src/bloqade/pyqrack test/pyqrack/runtime/test_qrack.py`
- `PYTHONPATH=src /Users/huahah/Documents/自主挣钱/work/bloqade-circuit/.venv/bin/python -m ruff check src/bloqade/pyqrack/task.py src/bloqade/pyqrack/device.py test/pyqrack/runtime/test_qrack.py`
- `git diff --check`

## AI Assistance Disclosure

This contribution was implemented with OpenAI Codex assistance. I reviewed the generated changes and ran the validation above locally.
