### PR TITLE
Remove quantum operations on empty qubit lists

### DIFF
--- a/src/bloqade/rewrite/passes/__init__.py
+++ b/src/bloqade/rewrite/passes/__init__.py
@@ -5,3 +5,4 @@ from .callgraph import (
 )
 from .aggressive_unroll import AggressiveUnroll as AggressiveUnroll
 from .canonicalize_ilist import CanonicalizeIList as CanonicalizeIList
+from .remove_empty_args import RemoveEmptyArgGates as RemoveEmptyArgGates

--- a/src/bloqade/rewrite/passes/remove_empty_args.py
+++ b/src/bloqade/rewrite/passes/remove_empty_args.py
@@ -1,0 +1,158 @@
+from dataclasses import field, dataclass
+
+from kirin import ir, types, passes
+from kirin.rewrite import Walk, Chain, Fixpoint, DeadCodeElimination
+from kirin.dialects import py, func, ilist
+from kirin.rewrite.abc import RewriteRule, RewriteResult
+
+from bloqade.types import MeasurementResultType
+from bloqade.squin import gate, noise
+from bloqade.qubit import stmts as qubit_stmts
+
+from .callgraph import CallGraphPass
+
+
+QuantumOperation = (
+    gate.stmts.Gate,
+    noise.stmts.NoiseChannel,
+    qubit_stmts.Measure,
+)
+QUBIT_ARG_NAMES = frozenset(("qubits", "controls", "targets"))
+BROADCAST_MODULE_PREFIXES = (
+    "bloqade.squin.stdlib.broadcast.",
+    "bloqade.qubit.stdlib.broadcast",
+)
+
+
+def _is_empty_ilist(type_: types.TypeAttribute) -> bool:
+    return (
+        isinstance(type_, types.Generic)
+        and type_.body == ilist.IListType.body
+        and isinstance(type_.vars[1], types.Literal)
+        and type_.vars[1].data == 0
+    )
+
+
+def _is_empty_ilist_value(value: ir.SSAValue) -> bool:
+    if _is_empty_ilist(value.type):
+        return True
+    if isinstance(value.owner, ilist.New):
+        return len(value.owner.values) == 0
+    if isinstance(value.owner, py.Constant):
+        data = value.owner.value.unwrap()
+        return isinstance(data, (list, tuple, ilist.IList)) and len(data) == 0
+    return False
+
+
+def _is_ilist(type_: types.TypeAttribute) -> bool:
+    return isinstance(type_, types.Generic) and type_.body == ilist.IListType.body
+
+
+def _is_quantum_operation_method(method: ir.Method) -> bool:
+    if method.py_func is None or not method.py_func.__module__.startswith(
+        BROADCAST_MODULE_PREFIXES
+    ):
+        return False
+    operations = [
+        stmt for stmt in method.code.walk() if isinstance(stmt, QuantumOperation)
+    ]
+    return len(operations) == 1
+
+
+def _replace_empty_results(node: ir.Statement) -> bool:
+    for result in node.results:
+        if not result.uses:
+            continue
+        result_type = result.type
+        if isinstance(node, func.Invoke):
+            result_type = node.callee.return_type
+        elif isinstance(node, qubit_stmts.Measure):
+            result_type = ilist.IListType[MeasurementResultType, types.Literal(0)]
+        if not _is_ilist(result_type):
+            return False
+
+    for result in node.results:
+        if not result.uses:
+            continue
+        result_type = (
+            node.callee.return_type if isinstance(node, func.Invoke) else result.type
+        )
+        if isinstance(node, qubit_stmts.Measure):
+            result_type = ilist.IListType[MeasurementResultType, types.Literal(0)]
+        elem_type = result_type.vars[0]
+        empty = ilist.New((), elem_type=elem_type)
+        empty.insert_before(node)
+        result.replace_by(empty.result)
+    return True
+
+
+@dataclass
+class RemoveEmptyArgOperations(RewriteRule):
+    """Remove quantum operations whose compile-time qubit lists are empty."""
+
+    def rewrite_Statement(self, node: ir.Statement) -> RewriteResult:
+        if isinstance(node, func.Invoke):
+            return self._rewrite_invoke(node)
+        if isinstance(node, QuantumOperation):
+            return self._rewrite_quantum_operation(node)
+        return RewriteResult()
+
+    def _rewrite_invoke(self, node: func.Invoke) -> RewriteResult:
+        if not _is_quantum_operation_method(node.callee):
+            return RewriteResult()
+
+        qubit_args = [
+            arg
+            for arg, arg_name in zip(node.inputs, node.callee.arg_names[1:])
+            if arg_name in QUBIT_ARG_NAMES
+        ]
+        if not qubit_args or not all(_is_empty_ilist_value(arg) for arg in qubit_args):
+            return RewriteResult()
+        if not _replace_empty_results(node):
+            return RewriteResult()
+
+        node.delete()
+        return RewriteResult(has_done_something=True)
+
+    def _rewrite_quantum_operation(self, node: ir.Statement) -> RewriteResult:
+        qubit_args = [
+            getattr(node, arg_name)
+            for arg_name in QUBIT_ARG_NAMES
+            if hasattr(node, arg_name)
+        ]
+        if not qubit_args or not all(_is_empty_ilist_value(arg) for arg in qubit_args):
+            return RewriteResult()
+        if not _replace_empty_results(node):
+            return RewriteResult()
+
+        node.delete()
+        return RewriteResult(has_done_something=True)
+
+
+@dataclass
+class RemoveEmptyArgGates(passes.Pass):
+    """Remove gates, noise channels, and measurements on empty qubit lists.
+
+    The pass walks the full call graph so it handles both direct quantum
+    statements and the stdlib functions normally used to construct them.
+    """
+
+    callgraph_pass: CallGraphPass = field(init=False)
+
+    def __post_init__(self):
+        rule = Fixpoint(
+            Walk(
+                Chain(
+                    RemoveEmptyArgOperations(),
+                    DeadCodeElimination(),
+                )
+            )
+        )
+        self.callgraph_pass = CallGraphPass(
+            dialects=self.dialects,
+            no_raise=self.no_raise,
+            rule=rule,
+        )
+
+    def unsafe_run(self, mt: ir.Method) -> RewriteResult:
+        return self.callgraph_pass.unsafe_run(mt)

--- a/test/rewrite/test_remove_empty_args.py
+++ b/test/rewrite/test_remove_empty_args.py
@@ -1,0 +1,168 @@
+from typing import Any
+
+from kirin.dialects import func, ilist
+
+from bloqade import squin
+from bloqade.squin import gate
+from bloqade.rewrite.passes import AggressiveUnroll, RemoveEmptyArgGates
+
+
+def test_removes_empty_stdlib_gate_and_noise_calls():
+    @squin.kernel
+    def main():
+        q = squin.qalloc(2)
+        squin.broadcast.h(q)
+        squin.broadcast.x([])
+        squin.broadcast.depolarize(0.1, [])
+
+    RemoveEmptyArgGates(main.dialects)(main)
+
+    invokes = [
+        stmt.callee.sym_name
+        for stmt in main.code.walk()
+        if isinstance(stmt, func.Invoke)
+    ]
+    assert "h" in invokes
+    assert "x" not in invokes
+    assert "depolarize" not in invokes
+
+
+def test_preserves_nonempty_gate_and_noise_calls():
+    @squin.kernel
+    def main():
+        q = squin.qalloc(2)
+        squin.broadcast.x(q)
+        squin.broadcast.depolarize(0.1, q)
+
+    RemoveEmptyArgGates(main.dialects)(main)
+
+    invokes = [
+        stmt.callee.sym_name
+        for stmt in main.code.walk()
+        if isinstance(stmt, func.Invoke)
+    ]
+    assert "x" in invokes
+    assert "depolarize" in invokes
+
+
+def test_removes_empty_measurement_and_preserves_empty_result():
+    @squin.kernel
+    def main():
+        measurements = squin.qubit.broadcast.measure([])
+        return len(measurements)
+
+    RemoveEmptyArgGates(main.dialects)(main)
+
+    assert main() == 0
+    assert not any(
+        isinstance(stmt, func.Invoke) and stmt.callee.sym_name == "measure"
+        for stmt in main.code.walk()
+    )
+
+
+def test_removes_nested_empty_qubit_lists():
+    @squin.kernel
+    def main():
+        squin.broadcast.correlated_qubit_loss(0.1, [])
+
+    RemoveEmptyArgGates(main.dialects)(main)
+
+    assert not any(
+        isinstance(stmt, func.Invoke)
+        and stmt.callee.sym_name == "correlated_qubit_loss"
+        for stmt in main.code.walk()
+    )
+
+
+def test_removes_two_qubit_gate_only_when_both_lists_are_empty():
+    @squin.kernel
+    def all_empty():
+        squin.broadcast.cx([], [])
+
+    @squin.kernel
+    def partially_empty():
+        q = squin.qalloc(1)
+        squin.broadcast.cx([], q)
+
+    RemoveEmptyArgGates(all_empty.dialects)(all_empty)
+    RemoveEmptyArgGates(partially_empty.dialects)(partially_empty)
+
+    assert not any(
+        isinstance(stmt, func.Invoke) and stmt.callee.sym_name == "cx"
+        for stmt in all_empty.code.walk()
+    )
+    assert any(
+        isinstance(stmt, func.Invoke) and stmt.callee.sym_name == "cx"
+        for stmt in partially_empty.code.walk()
+    )
+
+
+def test_preserves_nonquantum_function_called_with_empty_list():
+    @squin.kernel
+    def length(values: ilist.IList[int, Any]) -> int:
+        return len(values)
+
+    @squin.kernel
+    def main():
+        return length([])
+
+    RemoveEmptyArgGates(main.dialects)(main)
+
+    assert main() == 0
+
+
+def test_preserves_user_function_containing_quantum_operation():
+    @squin.kernel
+    def custom_gate(qubits: ilist.IList[squin.qubit.Qubit, Any]):
+        squin.broadcast.x(qubits)
+
+    @squin.kernel
+    def main():
+        custom_gate([])
+
+    RemoveEmptyArgGates(main.dialects)(main)
+
+    assert any(
+        isinstance(stmt, func.Invoke) and stmt.callee.sym_name == "custom_gate"
+        for stmt in main.code.walk()
+    )
+
+
+def test_removes_direct_gate_after_inlining():
+    @squin.kernel
+    def main():
+        squin.broadcast.x([])
+
+    AggressiveUnroll(main.dialects).fixpoint(main)
+    assert any(isinstance(stmt, gate.stmts.X) for stmt in main.code.walk())
+
+    RemoveEmptyArgGates(main.dialects)(main)
+
+    assert not any(isinstance(stmt, gate.stmts.X) for stmt in main.code.walk())
+
+
+def test_removes_direct_measurement_after_inlining():
+    @squin.kernel
+    def main():
+        return len(squin.qubit.broadcast.measure([]))
+
+    AggressiveUnroll(main.dialects).fixpoint(main)
+    RemoveEmptyArgGates(main.dialects)(main)
+
+    assert main() == 0
+
+
+def test_ignores_nonqubit_list_arguments():
+    probabilities = [0.0] * 15
+
+    @squin.kernel
+    def main():
+        squin.broadcast.two_qubit_pauli_channel(probabilities, [], [])
+
+    RemoveEmptyArgGates(main.dialects)(main)
+
+    assert not any(
+        isinstance(stmt, func.Invoke)
+        and stmt.callee.sym_name == "two_qubit_pauli_channel"
+        for stmt in main.code.walk()
+    )


### PR DESCRIPTION
Closes #516.

## Summary

- add `RemoveEmptyArgGates`, a call-graph rewrite pass that removes gates, noise channels, and measurements whose qubit IList arguments are compile-time empty
- handle both official Squin broadcast stdlib calls and direct quantum statements produced by inlining
- preserve typed empty measurement results when callers use them, then combine the rewrite with DCE
- conservatively preserve user-defined and non-quantum functions, non-qubit list arguments, and operations where only some qubit lists are empty

## Validation

- `python -m pytest test/rewrite/test_remove_empty_args.py -q` (`10 passed`)
- `python -m pytest test/rewrite/test_remove_empty_args.py test/squin/rewrite test/squin/test_stdlib_shorthands.py test/squin/noise/test_stdlib_noise.py -q` (`92 passed`)
- `ruff check src/bloqade/rewrite/passes/remove_empty_args.py src/bloqade/rewrite/passes/__init__.py test/rewrite/test_remove_empty_args.py`
- `ruff format --check src/bloqade/rewrite/passes/remove_empty_args.py src/bloqade/rewrite/passes/__init__.py test/rewrite/test_remove_empty_args.py`
- `git diff --check`

The repository-wide suite was also attempted, but collection requires optional `cirq`, `openqasm3`, and `tsim` dependencies that are not installed in the local environment.

## AI disclosure

I used OpenAI Codex to help inspect the IR and call-graph APIs, implement the rewrite, draft tests, and run validation. I manually reviewed the behavior, tightened the stdlib-call detection to avoid deleting user-defined wrappers, and take responsibility for the submitted changes.