### PR TITLE
Add SQUIN Clifford validation

### DIFF
--- a/src/bloqade/squin/analysis/validation/__init__.py
+++ b/src/bloqade/squin/analysis/validation/__init__.py
@@ -1,0 +1,1 @@
+from .clifford import CliffordValidation as CliffordValidation

--- a/src/bloqade/squin/analysis/validation/clifford.py
+++ b/src/bloqade/squin/analysis/validation/clifford.py
@@ -1,0 +1,76 @@
+from typing import Any
+
+from kirin import ir, interp
+from kirin.lattice import EmptyLattice
+from kirin.analysis import Forward
+from kirin.validation import ValidationPass
+from kirin.analysis.forward import ForwardFrame
+
+from bloqade.squin import gate
+from bloqade.rewrite.passes import AggressiveUnroll
+
+
+class _CliffordValidationAnalysis(Forward[EmptyLattice]):
+    keys = ["squin.validate.clifford"]
+
+    lattice = EmptyLattice
+
+    def method_self(self, method: ir.Method) -> EmptyLattice:
+        return self.lattice.bottom()
+
+    def eval_fallback(
+        self, frame: ForwardFrame[EmptyLattice], node: ir.Statement
+    ) -> tuple[EmptyLattice, ...]:
+        return tuple(self.lattice.bottom() for _ in range(len(node.results)))
+
+
+@gate.dialect.register(key="squin.validate.clifford")
+class _GateMethods(interp.MethodTable):
+    @interp.impl(gate.stmts.X)
+    @interp.impl(gate.stmts.Y)
+    @interp.impl(gate.stmts.Z)
+    @interp.impl(gate.stmts.H)
+    @interp.impl(gate.stmts.S)
+    @interp.impl(gate.stmts.SqrtX)
+    @interp.impl(gate.stmts.SqrtY)
+    @interp.impl(gate.stmts.CX)
+    @interp.impl(gate.stmts.CY)
+    @interp.impl(gate.stmts.CZ)
+    def clifford_gate(
+        self,
+        interp_: _CliffordValidationAnalysis,
+        frame: ForwardFrame[EmptyLattice],
+        stmt: gate.stmts.Gate,
+    ):
+        pass
+
+    @interp.impl(gate.stmts.T)
+    @interp.impl(gate.stmts.Rx)
+    @interp.impl(gate.stmts.Ry)
+    @interp.impl(gate.stmts.Rz)
+    @interp.impl(gate.stmts.U3)
+    @interp.impl(gate.stmts.PhasedXZ)
+    def non_clifford_gate(
+        self,
+        interp_: _CliffordValidationAnalysis,
+        frame: ForwardFrame[EmptyLattice],
+        stmt: gate.stmts.Gate,
+    ):
+        interp_.add_validation_error(
+            stmt,
+            ir.ValidationError(
+                stmt,
+                f"Gate {type(stmt).__name__} is not supported by CliffordValidation.",
+            ),
+        )
+
+
+class CliffordValidation(ValidationPass):
+    def name(self) -> str:
+        return "Squin Clifford Validation"
+
+    def run(self, method: ir.Method) -> tuple[Any, list[ir.ValidationError]]:
+        AggressiveUnroll(method.dialects).fixpoint(method)
+        analysis = _CliffordValidationAnalysis(method.dialects)
+        frame, _ = analysis.run(method)
+        return frame, analysis.get_validation_errors()

--- a/test/squin/validation/test_clifford.py
+++ b/test/squin/validation/test_clifford.py
@@ -1,0 +1,57 @@
+import pytest
+from kirin.validation import ValidationSuite
+from kirin.ir.exception import ValidationErrorGroup
+
+from bloqade import squin
+from bloqade.squin.analysis.validation import CliffordValidation
+
+
+def test_clifford_kernel_passes():
+    @squin.kernel
+    def main():
+        q = squin.qalloc(4)
+        squin.x(q[0])
+        squin.y(q[1])
+        squin.z(q[2])
+        squin.h(q[3])
+        squin.s(q[0])
+        squin.s_adj(q[1])
+        squin.sqrt_x(q[2])
+        squin.sqrt_x_adj(q[3])
+        squin.sqrt_y(q[0])
+        squin.sqrt_y_adj(q[1])
+        squin.cx(q[0], q[1])
+        squin.cy(q[1], q[2])
+        squin.cz(q[2], q[3])
+
+    result = ValidationSuite([CliffordValidation]).validate(main)
+    assert result.error_count() == 0
+
+
+def test_non_clifford_kernel_fails():
+    @squin.kernel
+    def main():
+        q = squin.qalloc(5)
+        squin.t(q[0])
+        squin.t_adj(q[1])
+        squin.rx(0.25, q[2])
+        squin.ry(0.5, q[3])
+        squin.rz(0.75, q[4])
+
+    result = ValidationSuite([CliffordValidation]).validate(main)
+    assert result.error_count() == 5
+
+    with pytest.raises(ValidationErrorGroup):
+        result.raise_if_invalid()
+
+
+def test_u3_and_phased_xz_fail():
+    @squin.kernel
+    def main():
+        q = squin.qalloc(2)
+        squin.u3(0.1, 0.2, 0.3, q[0])
+        squin.phased_xz(0.1, 0.2, 0.3, q[1])
+
+    _, errors = CliffordValidation().run(main)
+    assert len(errors) == 2
+    assert {type(error.node).__name__ for error in errors} == {"U3", "PhasedXZ"}


### PR DESCRIPTION
## Summary
- add a public `CliffordValidation` pass under `bloqade.squin.analysis.validation`
- run the existing aggressive SQUIN unroll inside the validator so user kernels expose concrete gate statements before validation
- reject non-Clifford SQUIN gate statements (`T`, arbitrary rotations, `U3`, `PhasedXZ`) while allowing the current Clifford gate set

Closes #665.

## Tests
- `timeout 120 uv run --no-dev --with pytest pytest test/squin/validation/test_clifford.py`
- `timeout 180 uv run --no-dev --with pytest pytest test/squin/validation/test_clifford.py test/squin/validation/test_simple_nocloning.py test/stim/from_squin_validation/test_from_squin_validation.py`
- `timeout 120 uv run --no-dev --with ruff ruff check src/bloqade/squin/analysis/validation/clifford.py test/squin/validation/test_clifford.py`
- `timeout 120 uv run --no-dev --with ruff ruff format --check src/bloqade/squin/analysis/validation/clifford.py test/squin/validation/test_clifford.py`
- `timeout 60 python3 -m compileall -q src/bloqade/squin/analysis/validation/clifford.py test/squin/validation/test_clifford.py && git diff --check`
