### PR TITLE
Emit SQUIN measurement-controlled if statements to Cirq

### DIFF
--- a/src/bloqade/cirq_utils/emit/base.py
+++ b/src/bloqade/cirq_utils/emit/base.py
@@ -6,11 +6,36 @@ import cirq
 from kirin import ir, types, interp
 from kirin.emit import EmitABC, EmitFrame
 from kirin.interp import MethodTable, impl
-from kirin.dialects import py, func, ilist
+from kirin.dialects import py, func, ilist, scf
+from kirin.ir.exception import ValidationErrorGroup
 from typing_extensions import Self
 
 from bloqade.squin import kernel
 from bloqade.rewrite.passes import AggressiveUnroll
+
+from .validation import CirqClassicalControlValidation
+
+
+@dataclass(frozen=True)
+class _MeasurementKeyRef:
+    key: cirq.MeasurementKey
+    bitmask: int | None = None
+
+
+def _classical_condition(
+    measurement: _MeasurementKeyRef, expected: bool | int, *, equal_target: bool
+) -> cirq.BitMaskKeyCondition:
+    expected_bit = int(expected)
+    target_value = expected_bit
+    if measurement.bitmask is not None:
+        target_value = measurement.bitmask if expected_bit else 0
+
+    return cirq.BitMaskKeyCondition(
+        measurement.key,
+        target_value=target_value,
+        equal_target=equal_target,
+        bitmask=measurement.bitmask,
+    )
 
 
 def emit_circuit(
@@ -156,6 +181,16 @@ def emit_circuit(
     )
 
     AggressiveUnroll(mt_.dialects).fixpoint(mt_)
+
+    _, validation_errors = CirqClassicalControlValidation().run(mt_)
+    if validation_errors:
+        details = "; ".join(str(error) for error in validation_errors)
+        raise ValidationErrorGroup(
+            f"Cirq classical control validation failed with {len(validation_errors)} "
+            f"error(s): {details}",
+            errors=validation_errors,
+        )
+
     emitter.initialize()
     emitter.run(mt_)
     return emitter.circuit
@@ -198,7 +233,6 @@ class EmitCirq(EmitABC[EmitCirqFrame, cirq.Circuit]):
 
 @func.dialect.register(key="emit.cirq")
 class __FuncEmit(MethodTable):
-
     @impl(func.Function)
     def emit_func(self, emit: EmitCirq, frame: EmitCirqFrame, stmt: func.Function):
         for block in stmt.body.blocks:
@@ -223,15 +257,46 @@ class __FuncEmit(MethodTable):
 
 @py.indexing.dialect.register(key="emit.cirq")
 class __Concrete(interp.MethodTable):
-
     @interp.impl(py.indexing.GetItem)
     def getindex(self, interp, frame: interp.Frame, stmt: py.indexing.GetItem):
-        # NOTE: no support for indexing into single statements in cirq
+        obj = frame.get(stmt.obj)
+        index = frame.get(stmt.index)
+
+        if isinstance(obj, ilist.IList) and isinstance(index, int):
+            return (obj[index],)
+
         return ()
 
     @interp.impl(py.Constant)
     def emit_constant(self, emit: EmitCirq, frame: EmitCirqFrame, stmt: py.Constant):
         return (stmt.value.data,)  # pyright: ignore[reportAttributeAccessIssue]
+
+
+@py.cmp.dialect.register(key="emit.cirq")
+class __Cmp(interp.MethodTable):
+    @interp.impl(py.cmp.Eq)
+    def eq(self, emit: EmitCirq, frame: EmitCirqFrame, stmt: py.cmp.Eq):
+        lhs = frame.get(stmt.lhs)
+        rhs = frame.get(stmt.rhs)
+
+        if isinstance(lhs, _MeasurementKeyRef) and rhs in (False, True, 0, 1):
+            return (_classical_condition(lhs, rhs, equal_target=True),)
+        if isinstance(rhs, _MeasurementKeyRef) and lhs in (False, True, 0, 1):
+            return (_classical_condition(rhs, lhs, equal_target=True),)
+
+        return (lhs == rhs,)
+
+    @interp.impl(py.cmp.NotEq)
+    def not_eq(self, emit: EmitCirq, frame: EmitCirqFrame, stmt: py.cmp.NotEq):
+        lhs = frame.get(stmt.lhs)
+        rhs = frame.get(stmt.rhs)
+
+        if isinstance(lhs, _MeasurementKeyRef) and rhs in (False, True, 0, 1):
+            return (_classical_condition(lhs, rhs, equal_target=False),)
+        if isinstance(rhs, _MeasurementKeyRef) and lhs in (False, True, 0, 1):
+            return (_classical_condition(rhs, lhs, equal_target=False),)
+
+        return (lhs != rhs,)
 
 
 @ilist.dialect.register(key="emit.cirq")
@@ -244,3 +309,41 @@ class __IList(interp.MethodTable):
         stmt: ilist.New,
     ):
         return (ilist.IList(data=frame.get_values(stmt.values)),)
+
+
+@scf.dialect.register(key="emit.cirq")
+class __Scf(interp.MethodTable):
+    @interp.impl(scf.Yield)
+    def yield_(self, emit: EmitCirq, frame: EmitCirqFrame, stmt: scf.Yield):
+        return frame.get_values(stmt.values)
+
+    @interp.impl(scf.IfElse)
+    def if_else(self, emit: EmitCirq, frame: EmitCirqFrame, stmt: scf.IfElse):
+        condition = frame.get(stmt.cond)
+        if not isinstance(condition, cirq.Condition):
+            raise interp.exceptions.InterpreterError(
+                "Cirq emission only supports if-statements controlled by a Cirq condition."
+            )
+
+        parent_circuit = emit.circuit
+        then_circuit = cirq.Circuit()
+
+        try:
+            emit.circuit = then_circuit
+            with emit.new_frame(stmt, has_parent_access=True) as then_frame:
+                then_frame.entries.update(frame.entries)
+                for child in stmt.then_body.blocks[0].stmts:
+                    result = emit.frame_eval(then_frame, child)
+                    if isinstance(result, tuple):
+                        then_frame.set_values(child.results, result)
+        finally:
+            emit.circuit = parent_circuit
+
+        operations = list(then_circuit.all_operations())
+        if len(operations) != 1:
+            raise interp.exceptions.InterpreterError(
+                "Cirq emission only supports one operation in a measurement-controlled if body."
+            )
+
+        emit.circuit.append(operations[0].with_classical_controls(condition))
+        return ()

--- a/src/bloqade/cirq_utils/emit/qubit.py
+++ b/src/bloqade/cirq_utils/emit/qubit.py
@@ -1,9 +1,10 @@
 import cirq
+from kirin.dialects import ilist
 from kirin.interp import MethodTable, impl
 
 from bloqade.qubit import stmts as qubit
 
-from .base import EmitCirq, EmitCirqFrame
+from .base import EmitCirq, EmitCirqFrame, _MeasurementKeyRef
 
 
 @qubit.dialect.register(key="emit.cirq")
@@ -23,8 +24,18 @@ class EmitCirqQubitMethods(MethodTable):
         self, emit: EmitCirq, frame: EmitCirqFrame, stmt: qubit.Measure
     ):
         qbits = frame.get(stmt.qubits)
-        emit.circuit.append(cirq.measure(qbits), strategy=cirq.InsertStrategy.NEW)
-        return (emit.void,)
+        measurement = cirq.measure(qbits)
+        emit.circuit.append(measurement, strategy=cirq.InsertStrategy.NEW)
+
+        (key,) = cirq.measurement_key_objs(measurement)
+        if len(qbits) == 1:
+            return (ilist.IList(data=[_MeasurementKeyRef(key)]),)
+
+        refs = [
+            _MeasurementKeyRef(key, bitmask=1 << (len(qbits) - index - 1))
+            for index in range(len(qbits))
+        ]
+        return (ilist.IList(data=refs),)
 
     @impl(qubit.Reset)
     def reset(self, emit: EmitCirq, frame: EmitCirqFrame, stmt: qubit.Reset):

--- a/src/bloqade/cirq_utils/emit/validation.py
+++ b/src/bloqade/cirq_utils/emit/validation.py
@@ -1,0 +1,105 @@
+from typing import Any
+
+from kirin import ir
+from kirin.dialects import ilist, py, scf
+from kirin.validation import ValidationPass
+
+from bloqade.qubit import stmts as qubit
+from bloqade.squin import gate
+
+
+def _constant_value(value: ir.SSAValue) -> Any:
+    owner = value.owner
+    if isinstance(owner, py.Constant):
+        return owner.value.data
+    return None
+
+
+def _is_single_measurement_result(value: ir.SSAValue) -> bool:
+    owner = value.owner
+    if not isinstance(owner, py.indexing.GetItem):
+        return False
+
+    if not isinstance(owner.index.owner, py.Constant):
+        return False
+
+    measure_stmt = owner.obj.owner
+    if not isinstance(measure_stmt, qubit.Measure):
+        return False
+
+    qubits_stmt = measure_stmt.qubits.owner
+    return isinstance(qubits_stmt, ilist.New) and len(qubits_stmt.values) == 1
+
+
+def _is_measurement_comparison(stmt: ir.Statement) -> bool:
+    if not isinstance(stmt, (py.cmp.Eq, py.cmp.NotEq)):
+        return False
+
+    lhs_is_measurement = _is_single_measurement_result(stmt.lhs)
+    rhs_is_measurement = _is_single_measurement_result(stmt.rhs)
+
+    if lhs_is_measurement == rhs_is_measurement:
+        return False
+
+    expected = _constant_value(stmt.rhs if lhs_is_measurement else stmt.lhs)
+    return expected in (False, True, 0, 1)
+
+
+def _is_empty_else(stmt: scf.IfElse) -> bool:
+    if len(stmt.else_body.blocks) != 1:
+        return False
+
+    else_stmts = list(stmt.else_body.blocks[0].stmts)
+    return len(else_stmts) == 1 and isinstance(else_stmts[0], scf.Yield)
+
+
+def _then_gate_count(stmt: scf.IfElse) -> int:
+    if len(stmt.then_body.blocks) != 1:
+        return 0
+
+    return sum(
+        1
+        for child in stmt.then_body.blocks[0].stmts
+        if isinstance(child, gate.stmts.Gate)
+    )
+
+
+class CirqClassicalControlValidation(ValidationPass):
+    def name(self) -> str:
+        return "Cirq classical control validation"
+
+    def run(self, method: ir.Method) -> tuple[None, list[ir.ValidationError]]:
+        errors: list[ir.ValidationError] = []
+
+        for stmt in method.callable_region.walk():
+            if not isinstance(stmt, scf.IfElse):
+                continue
+
+            if not _is_measurement_comparison(stmt.cond.owner):
+                errors.append(
+                    ir.ValidationError(
+                        stmt,
+                        "Cirq emission only supports if-statements controlled by a "
+                        "single measurement compared with True/False or 1/0.",
+                    )
+                )
+
+            if not _is_empty_else(stmt):
+                errors.append(
+                    ir.ValidationError(
+                        stmt,
+                        "Cirq emission only supports measurement-controlled if-statements "
+                        "with an empty else body.",
+                    )
+                )
+
+            if _then_gate_count(stmt) != 1:
+                errors.append(
+                    ir.ValidationError(
+                        stmt,
+                        "Cirq emission only supports measurement-controlled if-statements "
+                        "whose then body contains exactly one gate operation.",
+                    )
+                )
+
+        return None, errors

--- a/test/cirq_utils/test_clifford_to_cirq.py
+++ b/test/cirq_utils/test_clifford_to_cirq.py
@@ -5,6 +5,7 @@ import cirq
 import numpy as np
 import pytest
 from kirin.dialects import ilist
+from kirin.ir.exception import ValidationErrorGroup
 from kirin.interp.exceptions import InterpreterError
 
 from bloqade import squin
@@ -175,6 +176,55 @@ def test_measurement():
     print(circuit)
 
 
+def test_measurement_controlled_if_emits_classical_control():
+    @squin.kernel
+    def main():
+        q = squin.qalloc(2)
+        squin.h(q[0])
+        m = squin.measure(q[0])
+        if m == 0:
+            squin.x(q[1])
+
+    circuit = emit_circuit(main)
+    q = cirq.LineQubit.range(2)
+    expected = cirq.Circuit(
+        cirq.H(q[0]),
+        cirq.measure(q[0]),
+        cirq.X(q[1]).with_classical_controls(
+            cirq.BitMaskKeyCondition("q(0)", target_value=0, equal_target=True)
+        ),
+    )
+
+    assert circuit == expected
+
+
+def test_measurement_controlled_if_rejects_else_body():
+    @squin.kernel
+    def main():
+        q = squin.qalloc(2)
+        m = squin.measure(q[0])
+        if m == 0:
+            squin.x(q[1])
+        else:
+            squin.y(q[1])
+
+    with pytest.raises(ValidationErrorGroup, match="empty else body"):
+        emit_circuit(main)
+
+
+def test_measurement_controlled_if_rejects_multiple_gate_body():
+    @squin.kernel
+    def main():
+        q = squin.qalloc(2)
+        m = squin.measure(q[0])
+        if m == 1:
+            squin.x(q[1])
+            squin.z(q[1])
+
+    with pytest.raises(ValidationErrorGroup, match="exactly one gate operation"):
+        emit_circuit(main)
+
+
 def test_adjoint():
     @squin.kernel
     def main():
@@ -251,7 +301,6 @@ def test_additional_stmts():
 
 
 def test_return_measurement():
-
     @squin.kernel
     def coinflip():
         qubit = squin.qalloc(1)[0]
@@ -293,7 +342,6 @@ def test_qalloc_subroutines():
 
 
 def test_reset():
-
     @squin.kernel
     def main():
         q = squin.qalloc(4)


### PR DESCRIPTION
## Summary
- add a Cirq emitter validation pass for the supported measurement-controlled `if` shape
- preserve measurement keys through SQUIN measurement/getitem emission
- emit the single gate in a valid `if` body as a Cirq classically controlled operation

Closes #408.

## Validation
- `uv run pytest test/cirq_utils/test_clifford_to_cirq.py -q` (`25 passed`, one existing deprecation warning)
- `uv run pytest test/cirq_utils -q` (`315 passed, 1 xfailed`, one existing deprecation warning)
- `uv run ruff check src/bloqade/cirq_utils/emit/base.py src/bloqade/cirq_utils/emit/qubit.py src/bloqade/cirq_utils/emit/validation.py test/cirq_utils/test_clifford_to_cirq.py`
- `uv run ruff format --check src/bloqade/cirq_utils/emit/base.py src/bloqade/cirq_utils/emit/qubit.py src/bloqade/cirq_utils/emit/validation.py test/cirq_utils/test_clifford_to_cirq.py`
- `uv run python -m compileall -q src/bloqade/cirq_utils/emit test/cirq_utils/test_clifford_to_cirq.py`
- `git diff --check`

## Notes
AI assistance was used during implementation. I inspected the SQUIN IR shape, made the code changes, and ran the validation above before submitting.
