### PR TITLE
Add Clifford validation for SQUIN kernels

### DIFF
--- a/src/bloqade/squin/analysis/validation/__init__.py
+++ b/src/bloqade/squin/analysis/validation/__init__.py
@@ -1,0 +1,3 @@
+from .clifford import CliffordValidation as CliffordValidation
+
+__all__ = ["CliffordValidation"]

--- a/src/bloqade/squin/analysis/validation/clifford.py
+++ b/src/bloqade/squin/analysis/validation/clifford.py
@@ -1,0 +1,86 @@
+from typing import Any
+
+from kirin import ir, interp
+from kirin.lattice import EmptyLattice
+from kirin.analysis import Forward
+from kirin.dialects import func
+from kirin.validation import ValidationPass
+from kirin.analysis.forward import ForwardFrame
+
+from bloqade.squin import gate
+from bloqade.rewrite.passes import AggressiveUnroll
+
+
+class _CliffordValidationAnalysis(Forward[EmptyLattice]):
+    """Reject SQUIN kernels that contain syntactically non-Clifford gates."""
+
+    keys = ["validate.clifford"]
+    lattice = EmptyLattice
+
+    def method_self(self, method: ir.Method) -> EmptyLattice:
+        return self.lattice.bottom()
+
+    def eval_fallback(
+        self, frame: ForwardFrame[EmptyLattice], node: ir.Statement
+    ) -> tuple[EmptyLattice, ...]:
+        return tuple(self.lattice.bottom() for _ in range(len(node.results)))
+
+    def collect_error(self, stmt: ir.Statement) -> None:
+        self.add_validation_error(
+            stmt,
+            ir.ValidationError(
+                stmt,
+                f"Gate {stmt.name.upper()} is not a Clifford gate.",
+            ),
+        )
+
+
+@gate.dialect.register(key="validate.clifford")
+class _GateMethods(interp.MethodTable):
+    @interp.impl(gate.stmts.T)
+    @interp.impl(gate.stmts.Rx)
+    @interp.impl(gate.stmts.Ry)
+    @interp.impl(gate.stmts.Rz)
+    @interp.impl(gate.stmts.U3)
+    @interp.impl(gate.stmts.PhasedXZ)
+    def non_clifford_gate(
+        self,
+        interp_: _CliffordValidationAnalysis,
+        frame: ForwardFrame[EmptyLattice],
+        stmt: gate.stmts.Gate,
+    ) -> None:
+        interp_.collect_error(stmt)
+
+
+def _unroll_method(method: ir.Method) -> ir.Method:
+    symbol_op_trait = method.code.get_trait(ir.SymbolOpInterface)
+    signature_trait = method.code.get_trait(ir.HasSignature)
+
+    if symbol_op_trait is None or signature_trait is None:
+        return method
+
+    sym_name = symbol_op_trait.get_sym_name(method.code).unwrap()
+    unrolled_func = func.Function(
+        sym_name=sym_name,
+        body=method.callable_region.clone(),
+        signature=signature_trait.get_signature(method.code),
+    )
+    unrolled_method = ir.Method(
+        dialects=method.dialects,
+        code=unrolled_func,
+        sym_name=sym_name,
+    )
+
+    AggressiveUnroll(unrolled_method.dialects).fixpoint(unrolled_method)
+    return unrolled_method
+
+
+class CliffordValidation(ValidationPass):
+    def name(self) -> str:
+        return "Clifford Validation"
+
+    def run(self, method: ir.Method) -> tuple[Any, list[ir.ValidationError]]:
+        method = _unroll_method(method)
+        analysis = _CliffordValidationAnalysis(method.dialects)
+        frame, _ = analysis.run(method)
+        return frame, analysis.get_validation_errors()

--- a/test/squin/validation/test_clifford.py
+++ b/test/squin/validation/test_clifford.py
@@ -1,0 +1,84 @@
+import pytest
+from kirin.validation import ValidationSuite
+from kirin.ir.exception import ValidationErrorGroup
+
+from bloqade import squin
+from bloqade.rewrite.passes import AggressiveUnroll
+from bloqade.squin.analysis.validation import CliffordValidation
+
+
+def test_clifford_kernel_passes():
+    @squin.kernel
+    def main():
+        q = squin.qalloc(4)
+        squin.h(q[0])
+        squin.s(q[1])
+        squin.s_adj(q[1])
+        squin.sqrt_x(q[2])
+        squin.sqrt_y_adj(q[3])
+
+        for i in range(3):
+            squin.cx(q[i], q[i + 1])
+
+    AggressiveUnroll(main.dialects).fixpoint(main)
+
+    _, errors = CliffordValidation().run(main)
+    assert len(errors) == 0
+
+
+def test_issue_example_runs_without_manual_unroll():
+    @squin.kernel
+    def main_clifford():
+        q = squin.qalloc(4)
+        squin.h(q[0])
+        for i in range(3):
+            squin.cx(q[i], q[i + 1])
+
+    @squin.kernel
+    def main_nonclifford():
+        q = squin.qalloc(4)
+        squin.h(q[0])
+        for i in range(3):
+            squin.t(q[i])
+            squin.cx(q[i], q[i + 1])
+
+    assert len(CliffordValidation().run(main_clifford)[1]) == 0
+    assert len(CliffordValidation().run(main_nonclifford)[1]) > 0
+
+
+def test_non_clifford_t_gates_fail():
+    @squin.kernel
+    def main():
+        q = squin.qalloc(2)
+        squin.h(q[0])
+        squin.t(q[0])
+        squin.t_adj(q[1])
+
+    AggressiveUnroll(main.dialects).fixpoint(main)
+
+    validation_suite = ValidationSuite([CliffordValidation])
+    result = validation_suite.validate(main)
+    assert result.error_count() == 2
+
+    with pytest.raises(ValidationErrorGroup):
+        result.raise_if_invalid()
+
+
+def test_parameterized_gates_fail():
+    @squin.kernel
+    def main():
+        q = squin.qalloc(3)
+        squin.rx(0.125, q[0])
+        squin.ry(0.125, q[1])
+        squin.rz(0.125, q[2])
+        squin.u3(0.1, 0.2, 0.3, q[0])
+        squin.phased_xz(0.1, 0.2, 0.3, q[1])
+
+    AggressiveUnroll(main.dialects).fixpoint(main)
+
+    validation_suite = ValidationSuite([CliffordValidation])
+    result = validation_suite.validate(main)
+    assert result.error_count() == 5
+
+    with pytest.raises(ValidationErrorGroup):
+        result.raise_if_invalid()


### PR DESCRIPTION
Closes #665.

## Summary
- add `CliffordValidation` under `bloqade.squin.analysis.validation`
- clone and aggressively unroll SQUIN kernels before analysis so the validator catches stdlib and loop-expanded non-Clifford gates through the direct API shown in the issue
- report validation errors for syntactically non-Clifford SQUIN gates: `T`, `Rx`, `Ry`, `Rz`, `U3`, and `PhasedXZ`
- add regression coverage for the issue example, accepted Clifford gates, T/T-adjoint rejection, and parameterized gate rejection

## Validation
- `.\.venv\Scripts\python.exe -m pytest test\squin\validation\test_clifford.py test\squin\validation\test_simple_nocloning.py -q` -> 7 passed
- `.\.venv\Scripts\ruff.exe check src\bloqade\squin\analysis\validation\clifford.py src\bloqade\squin\analysis\validation\__init__.py test\squin\validation\test_clifford.py` -> passed
- `.\.venv\Scripts\ruff.exe format --check src\bloqade\squin\analysis\validation\clifford.py src\bloqade\squin\analysis\validation\__init__.py test\squin\validation\test_clifford.py` -> unchanged
- `.\.venv\Scripts\black.exe --check src\bloqade\squin\analysis\validation\clifford.py src\bloqade\squin\analysis\validation\__init__.py test\squin\validation\test_clifford.py` -> unchanged
- `py -3.12 -m compileall -q src\bloqade\squin\analysis\validation\clifford.py test\squin\validation\test_clifford.py` -> passed
- `git diff --cached --check` -> passed

## AI assistance disclosure
OpenAI Codex was used to inspect the validation patterns, draft the implementation and tests, and run local validation. I reviewed the resulting diff before submitting.