### PR TITLE
Emit simple squin if statements as Cirq classical controls

### DIFF
--- a/src/bloqade/cirq_utils/emit/base.py
+++ b/src/bloqade/cirq_utils/emit/base.py
@@ -5,12 +5,15 @@ from dataclasses import field, dataclass
 import cirq
 from kirin import ir, types, interp
 from kirin.emit import EmitABC, EmitFrame
+from kirin.ir.exception import ValidationErrorGroup
 from kirin.interp import MethodTable, impl
-from kirin.dialects import py, func, ilist
+from kirin.dialects import py, scf, func, ilist
 from typing_extensions import Self
 
 from bloqade.squin import kernel
 from bloqade.rewrite.passes import AggressiveUnroll
+
+from ..validation import CirqClassicalControlValidation
 
 
 def emit_circuit(
@@ -156,9 +159,22 @@ def emit_circuit(
     )
 
     AggressiveUnroll(mt_.dialects).fixpoint(mt_)
+
+    _, validation_errors = CirqClassicalControlValidation().run(mt_)
+    if validation_errors:
+        raise ValidationErrorGroup(
+            f"Cirq emission validation failed with {len(validation_errors)} error(s)",
+            errors=validation_errors,
+        )
+
     emitter.initialize()
     emitter.run(mt_)
     return emitter.circuit
+
+
+@dataclass(frozen=True)
+class CirqMeasurementResult:
+    key: cirq.MeasurementKey
 
 
 @dataclass
@@ -225,13 +241,45 @@ class __FuncEmit(MethodTable):
 class __Concrete(interp.MethodTable):
 
     @interp.impl(py.indexing.GetItem)
-    def getindex(self, interp, frame: interp.Frame, stmt: py.indexing.GetItem):
-        # NOTE: no support for indexing into single statements in cirq
+    def getindex(self, emit: EmitCirq, frame: interp.Frame, stmt: py.indexing.GetItem):
+        obj = frame.get(stmt.obj)
+        idx = frame.get(stmt.index)
+        if isinstance(obj, ilist.IList) and isinstance(idx, int):
+            return (obj[idx],)
+
         return ()
 
     @interp.impl(py.Constant)
     def emit_constant(self, emit: EmitCirq, frame: EmitCirqFrame, stmt: py.Constant):
         return (stmt.value.data,)  # pyright: ignore[reportAttributeAccessIssue]
+
+
+@py.cmp.dialect.register(key="emit.cirq")
+class __Cmp(interp.MethodTable):
+    @interp.impl(py.cmp.Eq)
+    def eq(self, emit: EmitCirq, frame: EmitCirqFrame, stmt: py.cmp.Eq):
+        lhs = frame.get(stmt.lhs)
+        rhs = frame.get(stmt.rhs)
+
+        if isinstance(lhs, CirqMeasurementResult) and rhs in (0, 1, False, True):
+            return (_measurement_condition(lhs, rhs),)
+
+        if isinstance(rhs, CirqMeasurementResult) and lhs in (0, 1, False, True):
+            return (_measurement_condition(rhs, lhs),)
+
+        return ()
+
+
+def _measurement_condition(
+    measurement: CirqMeasurementResult, expected: int | bool
+) -> cirq.BitMaskKeyCondition:
+    target_value = int(expected)
+    return cirq.BitMaskKeyCondition(
+        measurement.key,
+        target_value=target_value,
+        equal_target=True,
+        bitmask=1,
+    )
 
 
 @ilist.dialect.register(key="emit.cirq")
@@ -244,3 +292,49 @@ class __IList(interp.MethodTable):
         stmt: ilist.New,
     ):
         return (ilist.IList(data=frame.get_values(stmt.values)),)
+
+
+@scf.dialect.register(key="emit.cirq")
+class __Scf(interp.MethodTable):
+    @interp.impl(scf.Yield)
+    def emit_yield(self, emit: EmitCirq, frame: EmitCirqFrame, stmt: scf.Yield):
+        return frame.get_values(stmt.values)
+
+    @interp.impl(scf.IfElse)
+    def emit_if_else(self, emit: EmitCirq, frame: EmitCirqFrame, stmt: scf.IfElse):
+        condition = frame.get(stmt.cond)
+        if not isinstance(condition, cirq.Condition):
+            raise interp.InterpreterError(
+                "Cannot emit Cirq classical control: if condition is not based on "
+                "a supported measurement comparison."
+            )
+
+        parent_circuit = emit.circuit
+        body_circuit = cirq.Circuit()
+        emit.circuit = body_circuit
+
+        try:
+            with emit.new_frame(stmt) as then_frame:
+                then_frame.entries.update(frame.entries)
+                for child in stmt.then_body.blocks[0].stmts:
+                    then_frame.current_stmt = child
+                    child_results = emit.frame_eval(then_frame, child)
+                    if isinstance(child_results, tuple) and len(child_results) != 0:
+                        then_frame.set_values(child.results, child_results)
+        finally:
+            emit.circuit = parent_circuit
+
+        body_ops = list(body_circuit.all_operations())
+        if len(body_ops) != 1:
+            raise interp.InterpreterError(
+                "Cannot emit Cirq classical control: then-body must emit exactly "
+                "one Cirq operation."
+            )
+
+        emit.circuit.append(body_ops[0].with_classical_controls(condition))
+
+        term = stmt.then_body.blocks[0].last_stmt
+        if isinstance(term, scf.Yield):
+            return then_frame.get_values(term.values)
+
+        return ()

--- a/src/bloqade/cirq_utils/emit/qubit.py
+++ b/src/bloqade/cirq_utils/emit/qubit.py
@@ -3,7 +3,7 @@ from kirin.interp import MethodTable, impl
 
 from bloqade.qubit import stmts as qubit
 
-from .base import EmitCirq, EmitCirqFrame
+from .base import EmitCirq, EmitCirqFrame, CirqMeasurementResult
 
 
 @qubit.dialect.register(key="emit.cirq")
@@ -23,8 +23,10 @@ class EmitCirqQubitMethods(MethodTable):
         self, emit: EmitCirq, frame: EmitCirqFrame, stmt: qubit.Measure
     ):
         qbits = frame.get(stmt.qubits)
-        emit.circuit.append(cirq.measure(qbits), strategy=cirq.InsertStrategy.NEW)
-        return (emit.void,)
+        measure_op = cirq.measure(qbits)
+        emit.circuit.append(measure_op, strategy=cirq.InsertStrategy.NEW)
+        results = tuple(CirqMeasurementResult(measure_op.gate.key) for _ in qbits)
+        return (type(qbits)(data=results),)
 
     @impl(qubit.Reset)
     def reset(self, emit: EmitCirq, frame: EmitCirqFrame, stmt: qubit.Reset):

--- a/src/bloqade/cirq_utils/validation.py
+++ b/src/bloqade/cirq_utils/validation.py
@@ -1,0 +1,126 @@
+from typing import Any
+
+from kirin import ir, types
+from kirin.dialects import py, scf
+from kirin.validation import ValidationPass
+
+from bloqade.qubit import stmts as qubit_stmts
+from bloqade.squin import gate
+from bloqade.types import MeasurementResultType
+
+
+def _is_empty_else(stmt: scf.IfElse) -> bool:
+    if not stmt.else_body.blocks:
+        return True
+
+    else_stmts = list(stmt.else_body.blocks[0].stmts)
+    return len(else_stmts) == 1 and isinstance(else_stmts[0], scf.Yield)
+
+
+def _constant_bit(ssa: ir.SSAValue) -> int | None:
+    if not isinstance(ssa, ir.ResultValue) or not isinstance(ssa.owner, py.Constant):
+        return None
+
+    value = ssa.owner.value.unwrap()
+    if value in (0, 1, False, True):
+        return int(value)
+    return None
+
+
+def _measurement_operand(ssa: ir.SSAValue) -> ir.SSAValue | None:
+    if ssa.type != MeasurementResultType:
+        return None
+    return ssa
+
+
+def _is_single_measurement_result(ssa: ir.SSAValue) -> bool:
+    if not isinstance(ssa, ir.ResultValue):
+        return False
+
+    owner = ssa.owner
+    if not isinstance(owner, py.indexing.GetItem):
+        return False
+
+    if _constant_bit(owner.index) is None:
+        return False
+
+    if not isinstance(owner.obj, ir.ResultValue):
+        return False
+
+    measure_stmt = owner.obj.owner
+    if not isinstance(measure_stmt, qubit_stmts.Measure):
+        return False
+
+    measure_type = measure_stmt.qubits.type
+    if not measure_type.vars:
+        return False
+
+    length = measure_type.vars[1]
+    return isinstance(length, types.Literal) and length.data == 1
+
+
+def _supported_condition(stmt: scf.IfElse) -> bool:
+    if not isinstance(stmt.cond, ir.ResultValue) or not isinstance(
+        stmt.cond.owner, py.cmp.Eq
+    ):
+        return False
+
+    lhs = stmt.cond.owner.lhs
+    rhs = stmt.cond.owner.rhs
+    lhs_measurement = _measurement_operand(lhs)
+    rhs_measurement = _measurement_operand(rhs)
+
+    if lhs_measurement is not None and _constant_bit(rhs) is not None:
+        return _is_single_measurement_result(lhs_measurement)
+
+    if rhs_measurement is not None and _constant_bit(lhs) is not None:
+        return _is_single_measurement_result(rhs_measurement)
+
+    return False
+
+
+def _count_then_gates(stmt: scf.IfElse) -> int:
+    return sum(
+        1 for child in stmt.then_body.walk() if isinstance(child, gate.stmts.Gate)
+    )
+
+
+class CirqClassicalControlValidation(ValidationPass):
+    def name(self) -> str:
+        return "Cirq Classical Control Validation"
+
+    def run(self, method: ir.Method) -> tuple[Any, list[ir.ValidationError]]:
+        errors: list[ir.ValidationError] = []
+
+        for stmt in method.code.walk():
+            if not isinstance(stmt, scf.IfElse):
+                continue
+
+            if not _supported_condition(stmt):
+                errors.append(
+                    ir.ValidationError(
+                        stmt,
+                        "Cirq emission supports if statements only when the condition "
+                        "compares a single measurement result to 0, 1, False, or True.",
+                    )
+                )
+
+            if not _is_empty_else(stmt):
+                errors.append(
+                    ir.ValidationError(
+                        stmt,
+                        "Cirq emission supports measurement-controlled if statements "
+                        "only when the else body is empty.",
+                    )
+                )
+
+            if _count_then_gates(stmt) != 1:
+                errors.append(
+                    ir.ValidationError(
+                        stmt,
+                        "Cirq emission supports measurement-controlled if statements "
+                        "only when the then body contains exactly one gate operation.",
+                    )
+                )
+
+        return None, errors

--- a/test/cirq_utils/test_clifford_to_cirq.py
+++ b/test/cirq_utils/test_clifford_to_cirq.py
@@ -5,6 +5,7 @@ import cirq
 import numpy as np
 import pytest
 from kirin.dialects import ilist
+from kirin.ir.exception import ValidationErrorGroup
 from kirin.interp.exceptions import InterpreterError
 
 from bloqade import squin
@@ -173,6 +174,58 @@ def test_measurement():
     circuit = emit_circuit(main)
 
     print(circuit)
+
+
+def test_measurement_controlled_if():
+    @squin.kernel
+    def main():
+        q = squin.qalloc(1)
+        squin.h(q[0])
+        m = squin.measure(q[0])
+        if m == 0:
+            squin.x(q[0])
+
+    circuit = emit_circuit(main)
+    ops = list(circuit.all_operations())
+
+    assert ops[0] == cirq.H(cirq.LineQubit(0))
+    assert ops[1] == cirq.measure(cirq.LineQubit(0))
+    assert isinstance(ops[2], cirq.ClassicallyControlledOperation)
+    assert ops[2]._sub_operation == cirq.X(cirq.LineQubit(0))
+
+    condition = next(iter(ops[2].classical_controls))
+    assert isinstance(condition, cirq.BitMaskKeyCondition)
+    assert condition.key == cirq.MeasurementKey("q(0)")
+    assert condition.target_value == 0
+
+
+def test_measurement_controlled_if_one():
+    @squin.kernel
+    def main():
+        q = squin.qalloc(1)
+        m = squin.measure(q[0])
+        if m == 1:
+            squin.z(q[0])
+
+    op = list(emit_circuit(main).all_operations())[-1]
+    condition = next(iter(op.classical_controls))
+
+    assert isinstance(op, cirq.ClassicallyControlledOperation)
+    assert op._sub_operation == cirq.Z(cirq.LineQubit(0))
+    assert condition.target_value == 1
+
+
+def test_measurement_controlled_if_rejects_multiple_gates():
+    @squin.kernel
+    def main():
+        q = squin.qalloc(1)
+        m = squin.measure(q[0])
+        if m == 0:
+            squin.x(q[0])
+            squin.z(q[0])
+
+    with pytest.raises(ValidationErrorGroup, match="Cirq emission validation failed"):
+        emit_circuit(main)
 
 
 def test_adjoint():


### PR DESCRIPTION
Closes #408

Summary:
- Added Cirq emission support for simple measurement-conditioned squin if statements by lowering them to Cirq classical controls.
- Tracks single-qubit measurement results through emit, supports comparisons to 0/1/False/True, and validates unsupported if shapes before emitting.
- Added tests for controlled emission and invalid multi-gate then bodies.

Verification:
- python -m pytest test/cirq_utils/test_clifford_to_cirq.py -q
- python -m pytest test/cirq_utils -q
- python -m ruff check src/bloqade/cirq_utils/emit/base.py src/bloqade/cirq_utils/emit/qubit.py src/bloqade/cirq_utils/validation.py test/cirq_utils/test_clifford_to_cirq.py