### PR TITLE
feat(cirq): emit measurement-conditioned if statements as Cirq classical controls

### DIFF
--- a/src/bloqade/cirq_utils/emit/__init__.py
+++ b/src/bloqade/cirq_utils/emit/__init__.py
@@ -1,3 +1,6 @@
 # NOTE: just to register methods
-from . import gate as gate, noise as noise, qubit as qubit
+from . import scf as scf, gate as gate, noise as noise, qubit as qubit
 from .base import emit_circuit as emit_circuit
+from .validation import (
+    CirqClassicalControlValidation as CirqClassicalControlValidation,
+)

--- a/src/bloqade/cirq_utils/emit/base.py
+++ b/src/bloqade/cirq_utils/emit/base.py
@@ -12,6 +12,8 @@ from typing_extensions import Self
 from bloqade.squin import kernel
 from bloqade.rewrite.passes import AggressiveUnroll
 
+from .validation import CirqClassicalControlValidation
+
 
 def emit_circuit(
     mt: ir.Method,
@@ -156,6 +158,15 @@ def emit_circuit(
     )
 
     AggressiveUnroll(mt_.dialects).fixpoint(mt_)
+
+    _, validation_errors = CirqClassicalControlValidation().run(mt_)
+    if validation_errors:
+        messages = "\n".join(f"  - {err}" for err in validation_errors)
+        raise interp.exceptions.InterpreterError(
+            "Cannot emit one or more if-statements as Cirq classical controls:\n"
+            + messages
+        )
+
     emitter.initialize()
     emitter.run(mt_)
     return emitter.circuit
@@ -165,6 +176,9 @@ def emit_circuit(
 class EmitCirqFrame(EmitFrame):
     qubit_index: int = 0
     qubits: Sequence[cirq.Qid] | None = None
+    # Maps a qubit.Measure result SSA value to (cirq measurement key, qubits),
+    # used to emit measurement-conditioned if-statements as classical controls.
+    measurement_keys: dict = field(default_factory=dict)
 
 
 def _default_kernel():
@@ -226,8 +240,11 @@ class __Concrete(interp.MethodTable):
 
     @interp.impl(py.indexing.GetItem)
     def getindex(self, interp, frame: interp.Frame, stmt: py.indexing.GetItem):
-        # NOTE: no support for indexing into single statements in cirq
-        return ()
+        # NOTE: no support for indexing into single statements in cirq. Surviving
+        # GetItems (post AggressiveUnroll) only feed measurement-conditioned
+        # scf.IfElse conditions, which are resolved statically from the IR, so a
+        # None placeholder is enough to let the condition sub-graph evaluate.
+        return (None,)
 
     @interp.impl(py.Constant)
     def emit_constant(self, emit: EmitCirq, frame: EmitCirqFrame, stmt: py.Constant):

--- a/src/bloqade/cirq_utils/emit/classical_control.py
+++ b/src/bloqade/cirq_utils/emit/classical_control.py
@@ -1,0 +1,132 @@
+"""Helpers for emitting measurement-conditioned ``scf.IfElse`` statements as
+Cirq classical controls (``cirq.ClassicallyControlledOperation``).
+
+The single source of truth for *which* ``if`` shapes can be emitted lives in
+:func:`trace_condition`. Both the validation pass (``validation.py``) and the
+emit method table (``scf.py``) call it so that validation and emission can never
+disagree.
+"""
+
+import sympy
+from kirin import ir
+from kirin.dialects import py, ilist
+
+from bloqade.qubit import stmts as qubit_stmts
+
+
+class ConditionError(Exception):
+    """Raised when an ``scf.IfElse`` condition cannot be expressed as a Cirq
+    classical control."""
+
+
+def _const_bit(value: ir.SSAValue) -> int | None:
+    """Return ``0``/``1`` if ``value`` is a constant ``0``/``1``/``False``/``True``,
+    else ``None``."""
+    if isinstance(value, ir.ResultValue) and isinstance(value.owner, py.Constant):
+        data = value.owner.value.unwrap()
+        if isinstance(data, bool):
+            return int(data)
+        if data == 0:
+            return 0
+        if data == 1:
+            return 1
+    return None
+
+
+def _trace_cmp(
+    stmt: "py.cmp.Eq | py.cmp.NotEq", polarity: int, *, eq: bool
+) -> tuple[ir.SSAValue, int]:
+    lhs_bit = _const_bit(stmt.lhs)
+    rhs_bit = _const_bit(stmt.rhs)
+    if lhs_bit is not None and rhs_bit is None:
+        bit, other = lhs_bit, stmt.rhs
+    elif rhs_bit is not None and lhs_bit is None:
+        bit, other = rhs_bit, stmt.lhs
+    else:
+        raise ConditionError(
+            "comparison condition must compare a measurement to a constant "
+            "0, 1, False or True"
+        )
+    # `polarity` == 1 means "control fires when the measured qubit is |1>".
+    # eq & bit==1  -> fire on |1> (keep);   eq & bit==0  -> fire on |0> (flip)
+    # neq & bit==1 -> fire on |0> (flip);   neq & bit==0 -> fire on |1> (keep)
+    keep = (bit == 1) == eq
+    new_polarity = polarity if keep else 1 - polarity
+    return trace_condition(other, new_polarity)
+
+
+def trace_condition(cond: ir.SSAValue, polarity: int = 1) -> tuple[ir.SSAValue, int]:
+    """Walk the SSA def-chain of an ``scf.IfElse`` condition back to the
+    ``qubit.Measure`` it derives from.
+
+    Returns ``(measure_result, polarity)`` where ``measure_result`` is the SSA
+    value produced by the originating ``qubit.Measure`` statement and
+    ``polarity`` is ``1`` if the control fires when the qubit is measured in
+    ``|1>`` and ``0`` if it fires on ``|0>``.
+
+    Raises :class:`ConditionError` for any shape that has no Cirq
+    classical-control equivalent.
+    """
+    if not isinstance(cond, ir.ResultValue):
+        raise ConditionError(
+            "condition must derive from a measurement, but is a block argument"
+        )
+
+    owner = cond.owner
+
+    if isinstance(owner, qubit_stmts.Measure):
+        return cond, polarity
+    if isinstance(owner, qubit_stmts.IsOne):
+        return trace_condition(owner.measurements, polarity)
+    if isinstance(owner, qubit_stmts.IsZero):
+        return trace_condition(owner.measurements, 1 - polarity)
+    if isinstance(owner, qubit_stmts.IsLost):
+        raise ConditionError(
+            "the is_lost predicate has no Cirq classical-control equivalent"
+        )
+    if isinstance(owner, py.indexing.GetItem):
+        return trace_condition(owner.obj, polarity)
+    if isinstance(owner, ilist.New):
+        if len(owner.values) != 1:
+            raise ConditionError(
+                "only conditions based on a single measurement are supported"
+            )
+        return trace_condition(owner.values[0], polarity)
+    if isinstance(owner, ilist.Foldl):
+        # produced by load_circuit when importing a Cirq classical control:
+        # foldl(or, measurement_results, init=False) reduces a length-1 list.
+        return trace_condition(owner.collection, polarity)
+    if isinstance(owner, py.cmp.Eq):
+        return _trace_cmp(owner, polarity, eq=True)
+    if isinstance(owner, py.cmp.NotEq):
+        return _trace_cmp(owner, polarity, eq=False)
+
+    raise ConditionError(
+        f"unsupported condition statement '{type(owner).__name__}'; the "
+        "condition must be a single measurement compared to 0/1 or wrapped in "
+        "is_one/is_zero"
+    )
+
+
+def measure_num_qubits(measure_result: ir.SSAValue) -> int | None:
+    """Best-effort count of qubits feeding the originating ``qubit.Measure``.
+
+    Returns ``None`` if it cannot be determined statically."""
+    owner = measure_result.owner
+    if not isinstance(owner, qubit_stmts.Measure):
+        return None
+    qubits = owner.qubits
+    if isinstance(qubits, ir.ResultValue) and isinstance(qubits.owner, ilist.New):
+        return len(qubits.owner.values)
+    return None
+
+
+def build_cirq_condition(key: str, polarity: int):
+    """Build the Cirq classical-control condition for a measurement ``key``.
+
+    ``polarity == 1`` -> fire on ``|1>`` (a Cirq ``KeyCondition``, expressed as
+    the bare key string). ``polarity == 0`` -> fire on ``|0>`` (a
+    ``SympyCondition`` ``Eq(key, 0)``)."""
+    if polarity == 1:
+        return key
+    return sympy.Eq(sympy.Symbol(key), 0)

--- a/src/bloqade/cirq_utils/emit/qubit.py
+++ b/src/bloqade/cirq_utils/emit/qubit.py
@@ -23,7 +23,11 @@ class EmitCirqQubitMethods(MethodTable):
         self, emit: EmitCirq, frame: EmitCirqFrame, stmt: qubit.Measure
     ):
         qbits = frame.get(stmt.qubits)
-        emit.circuit.append(cirq.measure(qbits), strategy=cirq.InsertStrategy.NEW)
+        measure_op = cirq.measure(qbits)
+        emit.circuit.append(measure_op, strategy=cirq.InsertStrategy.NEW)
+        # Record the measurement key so a downstream measurement-conditioned
+        # scf.IfElse can be emitted as a Cirq classical control.
+        frame.measurement_keys[stmt.result] = (measure_op.gate.key, list(qbits))
         return (emit.void,)
 
     @impl(qubit.Reset)

--- a/src/bloqade/cirq_utils/emit/scf.py
+++ b/src/bloqade/cirq_utils/emit/scf.py
@@ -1,0 +1,62 @@
+import cirq
+from kirin import interp
+from kirin.interp import MethodTable, impl
+from kirin.dialects import scf
+
+from .base import EmitCirq, EmitCirqFrame
+from .classical_control import (
+    ConditionError,
+    trace_condition,
+    build_cirq_condition,
+)
+
+
+@scf.dialect.register(key="emit.cirq")
+class EmitCirqScfMethods(MethodTable):
+    @impl(scf.IfElse)
+    def if_else(self, emit: EmitCirq, frame: EmitCirqFrame, stmt: scf.IfElse):
+        try:
+            measure_result, polarity = trace_condition(stmt.cond)
+        except ConditionError as e:
+            # validation should have caught this; re-raise as an interpreter
+            # error in case emit_circuit was bypassed.
+            raise interp.exceptions.InterpreterError(
+                f"Cannot emit if-statement as a Cirq classical control: {e}"
+            )
+
+        key_info = frame.measurement_keys.get(measure_result)
+        if key_info is None:
+            raise interp.exceptions.InterpreterError(
+                "Cannot emit if-statement as a Cirq classical control: the "
+                "condition's measurement was not emitted before the if-statement."
+            )
+        key, _ = key_info
+        condition = build_cirq_condition(key, polarity)
+
+        # Emit the then-body into a scratch circuit using the *same* frame so
+        # that qubit allocation state (qubit_index, entries) is shared with the
+        # parent scope, then graft the resulting operations back as classically
+        # controlled operations.
+        then_block = stmt.then_body.blocks[0]
+        saved_circuit = emit.circuit
+        emit.circuit = cirq.Circuit()
+        try:
+            for body_stmt in then_block.stmts:
+                if isinstance(body_stmt, scf.Yield):
+                    continue
+                frame.current_stmt = body_stmt
+                results = emit.frame_eval(frame, body_stmt)
+                if isinstance(results, tuple) and len(results) != 0:
+                    frame.set_values(body_stmt.results, results)
+            body_circuit = emit.circuit
+        finally:
+            emit.circuit = saved_circuit
+
+        for op in body_circuit.all_operations():
+            saved_circuit.append(
+                op.with_classical_controls(condition),
+                strategy=cirq.InsertStrategy.NEW,
+            )
+
+        # scf.IfElse here yields nothing (empty Yield) -> no result values.
+        return ()

--- a/src/bloqade/cirq_utils/emit/validation.py
+++ b/src/bloqade/cirq_utils/emit/validation.py
@@ -1,0 +1,120 @@
+"""Validation for emitting ``scf.IfElse`` statements as Cirq classical controls.
+
+An ``if`` statement can be emitted as a classical control only when:
+
+* its condition derives from a single measurement, compared against
+  ``0``/``1``/``False``/``True`` or wrapped in ``is_one`` / ``is_zero``;
+* the ``else`` body is empty;
+* the ``then`` body contains exactly one gate operation and no allocations,
+  measurements, resets, nested control flow or sub-kernel calls.
+"""
+
+from typing import Any
+
+from kirin import ir
+from kirin.dialects import scf, func
+from kirin.validation import ValidationPass
+
+from bloqade.qubit import stmts as qubit_stmts
+from bloqade.squin import gate
+
+from .classical_control import (
+    ConditionError,
+    trace_condition,
+    measure_num_qubits,
+)
+
+# Statements that must never appear inside a classically-controlled then-body.
+_FORBIDDEN_IN_BODY = (
+    qubit_stmts.New,
+    qubit_stmts.Measure,
+    qubit_stmts.Reset,
+    scf.IfElse,
+    scf.For,
+    func.Invoke,
+    func.Call,
+)
+
+
+def _validate_if_else(stmt: scf.IfElse, errors: list[ir.ValidationError]) -> None:
+    # --- else body must be empty (only a terminating yield) ---
+    for block in stmt.else_body.blocks:
+        for child in block.stmts:
+            if not isinstance(child, scf.Yield):
+                errors.append(
+                    ir.ValidationError(
+                        stmt,
+                        "Cannot emit an if-statement with a non-empty else body "
+                        "as a Cirq classical control.",
+                    )
+                )
+                break
+
+    # --- then body must contain exactly one gate and nothing disallowed ---
+    gate_count = 0
+    then_blocks = stmt.then_body.blocks
+    if len(then_blocks) != 1:
+        errors.append(
+            ir.ValidationError(
+                stmt,
+                "Cannot emit an if-statement whose then-body has multiple blocks "
+                "as a Cirq classical control.",
+            )
+        )
+    for block in then_blocks:
+        for child in block.stmts:
+            if isinstance(child, gate.stmts.Gate):
+                gate_count += 1
+            elif isinstance(child, _FORBIDDEN_IN_BODY):
+                errors.append(
+                    ir.ValidationError(
+                        stmt,
+                        "Cannot emit an if-statement as a Cirq classical control: "
+                        f"the then-body contains an unsupported statement "
+                        f"'{type(child).__name__}'. Only a single gate operation "
+                        "is allowed.",
+                    )
+                )
+
+    if gate_count != 1:
+        errors.append(
+            ir.ValidationError(
+                stmt,
+                "Cannot emit an if-statement as a Cirq classical control: the "
+                f"then-body must contain exactly one gate operation, found "
+                f"{gate_count}.",
+            )
+        )
+
+    # --- condition must resolve to a single-qubit measurement ---
+    try:
+        measure_result, _ = trace_condition(stmt.cond)
+    except ConditionError as e:
+        errors.append(ir.ValidationError(stmt, f"Unsupported if-condition: {e}."))
+        return
+
+    num_qubits = measure_num_qubits(measure_result)
+    if num_qubits is not None and num_qubits != 1:
+        errors.append(
+            ir.ValidationError(
+                stmt,
+                "Cannot emit an if-statement as a Cirq classical control: the "
+                "condition must be based on a single-qubit measurement, but the "
+                f"measurement acts on {num_qubits} qubits.",
+            )
+        )
+
+
+class CirqClassicalControlValidation(ValidationPass):
+    """Validate that every ``scf.IfElse`` in a kernel can be emitted as a Cirq
+    classical control."""
+
+    def name(self) -> str:
+        return "Cirq Classical Control Validation"
+
+    def run(self, method: ir.Method) -> tuple[Any, list[ir.ValidationError]]:
+        errors: list[ir.ValidationError] = []
+        for node in method.callable_region.walk():
+            if isinstance(node, scf.IfElse):
+                _validate_if_else(node, errors)
+        return None, errors

--- a/test/cirq_utils/test_classical_control.py
+++ b/test/cirq_utils/test_classical_control.py
@@ -1,0 +1,184 @@
+"""Tests for emitting measurement-conditioned squin if-statements as Cirq
+classical controls (issue #408)."""
+
+import cirq
+import pytest
+from kirin.interp.exceptions import InterpreterError
+
+from bloqade import squin
+from bloqade.cirq_utils import emit_circuit, load_circuit
+
+
+def _controlled_ops(circuit: cirq.Circuit) -> list[cirq.ClassicallyControlledOperation]:
+    return [
+        op
+        for op in circuit.all_operations()
+        if isinstance(op, cirq.ClassicallyControlledOperation)
+    ]
+
+
+def _condition_strs(op: cirq.ClassicallyControlledOperation) -> list[str]:
+    return [str(c) for c in op.classical_controls]
+
+
+def test_emit_is_one_as_key_condition():
+    @squin.kernel
+    def main():
+        q = squin.qalloc(1)
+        squin.h(q[0])
+        m = squin.measure(q[0])
+        if squin.is_one(m):
+            squin.x(q[0])
+
+    circuit = emit_circuit(main)
+    controlled = _controlled_ops(circuit)
+    assert len(controlled) == 1
+    op = controlled[0]
+    # fires on |1>: a bare KeyCondition on the measurement key
+    assert _condition_strs(op) == ["q(0)"]
+    assert isinstance(op.without_classical_controls(), cirq.GateOperation)
+    assert op.without_classical_controls().gate == cirq.X
+
+
+def test_emit_is_zero_as_sympy_condition():
+    @squin.kernel
+    def main():
+        q = squin.qalloc(1)
+        m = squin.measure(q[0])
+        if squin.is_zero(m):
+            squin.x(q[0])
+
+    circuit = emit_circuit(main)
+    controlled = _controlled_ops(circuit)
+    assert len(controlled) == 1
+    # fires on |0>: Eq(key, 0)
+    assert _condition_strs(controlled[0]) == ["Eq(q(0), 0)"]
+
+
+def test_emit_eq_zero_comparison():
+    @squin.kernel
+    def main():
+        q = squin.qalloc(1)
+        m = squin.measure(q[0])
+        if m == 0:
+            squin.x(q[0])
+
+    controlled = _controlled_ops(emit_circuit(main))
+    assert len(controlled) == 1
+    assert _condition_strs(controlled[0]) == ["Eq(q(0), 0)"]
+
+
+def test_emit_eq_one_comparison():
+    @squin.kernel
+    def main():
+        q = squin.qalloc(1)
+        m = squin.measure(q[0])
+        if m == 1:
+            squin.x(q[0])
+
+    controlled = _controlled_ops(emit_circuit(main))
+    assert len(controlled) == 1
+    assert _condition_strs(controlled[0]) == ["q(0)"]
+
+
+def test_round_trip_classical_control():
+    """A Cirq classical control survives cirq -> squin -> cirq."""
+    q0, q1 = cirq.LineQubit.range(2)
+    circuit = cirq.Circuit(
+        cirq.H(q0),
+        cirq.measure(q0, key="a"),
+        cirq.X(q1).with_classical_controls("a"),
+    )
+    mt = load_circuit(circuit)
+    out = emit_circuit(mt)
+    controlled = _controlled_ops(out)
+    assert len(controlled) == 1
+    # the imported control is preserved: an X classically controlled on q0's measurement
+    op = controlled[0]
+    assert op.without_classical_controls().gate == cirq.X
+    assert len(op.classical_controls) == 1
+
+
+def test_feed_forward_semantics():
+    """if is_one(m): X(other)  flips the target exactly when the control fired."""
+
+    @squin.kernel
+    def main():
+        q = squin.qalloc(2)
+        squin.x(q[0])  # q0 := |1>
+        m = squin.measure(q[0])
+        if squin.is_one(m):  # always true here
+            squin.x(q[1])  # so q1 becomes |1>
+        squin.measure(q[1])
+
+    circuit = emit_circuit(main)
+    result = cirq.Simulator().run(circuit, repetitions=64)
+    target_key = "q(1)"
+    assert (result.measurements[target_key] == 1).all()
+
+
+def test_no_if_is_unchanged():
+    """Kernels without if-statements are unaffected."""
+
+    @squin.kernel
+    def main():
+        q = squin.qalloc(2)
+        squin.h(q[0])
+        squin.cx(q[0], q[1])
+
+    circuit = emit_circuit(main)
+    assert _controlled_ops(circuit) == []
+
+
+def test_error_multiple_gates_in_body():
+    @squin.kernel
+    def main():
+        q = squin.qalloc(1)
+        m = squin.measure(q[0])
+        if squin.is_one(m):
+            squin.x(q[0])
+            squin.y(q[0])
+
+    with pytest.raises(InterpreterError, match="exactly one gate"):
+        emit_circuit(main)
+
+
+def test_error_non_empty_else():
+    @squin.kernel
+    def main():
+        q = squin.qalloc(1)
+        m = squin.measure(q[0])
+        if squin.is_one(m):
+            squin.x(q[0])
+        else:
+            squin.y(q[0])
+
+    with pytest.raises(InterpreterError, match="else body"):
+        emit_circuit(main)
+
+
+def test_error_is_lost_condition():
+    @squin.kernel
+    def main():
+        q = squin.qalloc(1)
+        m = squin.measure(q[0])
+        if squin.is_lost(m):
+            squin.x(q[0])
+
+    with pytest.raises(InterpreterError, match="is_lost"):
+        emit_circuit(main)
+
+
+def test_error_allocation_in_body():
+    """The qubit-allocation-in-then-body shape (the bug that closed PR #790)."""
+
+    @squin.kernel
+    def main():
+        q = squin.qalloc(1)
+        m = squin.measure(q[0])
+        if squin.is_one(m):
+            r = squin.qalloc(1)
+            squin.x(r[0])
+
+    with pytest.raises(InterpreterError, match="unsupported statement"):
+        emit_circuit(main)


### PR DESCRIPTION

Closes #408. Also fixes #474 (emit silently ignoring feed-forward `if`s).

## What this does

`emit_circuit` currently drops `if` statements on the floor, so a measurement-conditioned gate just disappears from the resulting `cirq.Circuit`. This adds an emit path for `scf.IfElse` that turns a single-measurement `if` into a `cirq.ClassicallyControlledOperation`.

The example from the issue now works:

```python
@squin.kernel
def main():
    q = squin.qalloc(1)
    squin.h(q[0])
    m = squin.measure(q[0])
    if m == 0:
        squin.x(q[0])

print(emit_circuit(main))
# 0: ──────H───M───X(conditions=[Eq(q(0), 0)])───
#              ║   ║
# q(0): ═══════@═══^═══════════════════════════════
```

## How it works

The condition can show up in a few shapes depending on how the kernel was written, so I resolve it back to the originating measurement instead of pattern-matching one fixed form. `trace_condition` (in `classical_control.py`) walks the SSA def-chain of `scf.IfElse.cond` back to the `qubit.Measure` it came from and tracks a polarity bit along the way. Supported conditions:

| squin condition        | cirq control                   |
| ---------------------- | ------------------------------ |
| `is_one(m)`, `m == 1`  | `KeyCondition` (fires on \|1>) |
| `is_zero(m)`, `m == 0` | `SympyCondition` `Eq(key, 0)`  |
| `m != 0`, `m != 1`     | same path, polarity flipped    |

It also recognises the `ilist.Foldl` reduce shape that `load_circuit` produces when importing a Cirq classical control, so a control survives a `cirq -> squin -> cirq` round-trip.

Emit reuses the existing gate method table: the then-body is emitted into a scratch circuit on the same frame (so qubit allocation indices stay consistent with the parent scope), then each resulting op is re-appended with `with_classical_controls(condition)`.

## Validation

`CirqClassicalControlValidation` is a `ValidationPass` run inside `emit_circuit` after unrolling. It rejects shapes that have no clean Cirq equivalent and raises a readable error instead of emitting something wrong:

- condition not based on a single-qubit measurement
- `is_lost` condition (no Cirq equivalent)
- non-empty `else` body
- a then-body that is not exactly one gate (allocations, measurements, resets, nested control flow, sub-kernel calls are all rejected)

## Tests

Added `test/cirq_utils/test_classical_control.py` covering `is_one`/`is_zero`, `==`/`!=` comparisons, the cirq round-trip, feed-forward simulation semantics, and each rejected shape. Full `test/cirq_utils` suite passes locally (323 passed, 1 xfailed) with no regressions. `ruff`/`black`/`isort` clean.

Developed with AI assistance; I went through the IR shapes myself, verified the emitted circuits, and ran the suite before opening this.
