### PR TITLE
Add SQUIN Clifford validation pass

### DIFF
--- a/src/bloqade/squin/analysis/validation/__init__.py
+++ b/src/bloqade/squin/analysis/validation/__init__.py
@@ -1,0 +1,1 @@
+from .clifford import CliffordValidation as CliffordValidation

--- a/src/bloqade/squin/analysis/validation/__init__.py
+++ b/src/bloqade/squin/analysis/validation/__init__.py
@@ -1,1 +1,3 @@
+"""Validation passes for SQUIN analysis."""
+
 from .clifford import CliffordValidation as CliffordValidation

--- a/src/bloqade/squin/analysis/validation/clifford.py
+++ b/src/bloqade/squin/analysis/validation/clifford.py
@@ -78,9 +78,11 @@ class CliffordValidation(ValidationPass):
     """Validate that a SQUIN kernel contains only Clifford gates."""
 
     def name(self) -> str:
+        """Return the validation pass name."""
         return "Clifford Validation"
 
     def run(self, method: ir.Method) -> tuple[Any, list[ir.ValidationError]]:
+        """Run Clifford-only validation for a SQUIN method."""
         errors: list[ir.ValidationError] = []
 
         AggressiveUnroll(method.dialects).fixpoint(method)

--- a/src/bloqade/squin/analysis/validation/clifford.py
+++ b/src/bloqade/squin/analysis/validation/clifford.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+from kirin import ir
+from kirin.dialects import py
+from kirin.validation import ValidationPass
+
+from bloqade.squin import gate
+from bloqade.rewrite.passes import AggressiveUnroll
+from bloqade.squin.rewrite.U3_to_clifford import SquinU3ToClifford
+
+_CLIFFORD_GATES = (
+    gate.stmts.X,
+    gate.stmts.Y,
+    gate.stmts.Z,
+    gate.stmts.H,
+    gate.stmts.S,
+    gate.stmts.SqrtX,
+    gate.stmts.SqrtY,
+    gate.stmts.CX,
+    gate.stmts.CY,
+    gate.stmts.CZ,
+)
+
+
+def _constant_turn(value: ir.SSAValue) -> float | None:
+    if not isinstance(value, ir.ResultValue) or not isinstance(
+        value.owner, py.Constant
+    ):
+        return None
+    unwrapped = value.owner.value.unwrap()
+    if isinstance(unwrapped, (int, float)):
+        return float(unwrapped)
+    return None
+
+
+def _is_quarter_turn(value: ir.SSAValue) -> bool:
+    turn = _constant_turn(value)
+    if turn is None:
+        return False
+    quarter_turns = turn * 4.0
+    return np.isclose(quarter_turns, round(quarter_turns))
+
+
+def _is_clifford_rotation(stmt: gate.stmts.RotationGate) -> bool:
+    return _is_quarter_turn(stmt.angle)
+
+
+def _is_clifford_u3(stmt: gate.stmts.U3) -> bool:
+    return bool(SquinU3ToClifford().decompose_U3_gates(stmt))
+
+
+def _is_clifford_phased_xz(stmt: gate.stmts.PhasedXZ) -> bool:
+    # PhasedXZ is Rz(-axis_phase) Rx(x) Rz(axis_phase + z). Requiring all
+    # exposed turn parameters to be quarter-turns is conservative and keeps the
+    # validation pass non-mutating.
+    return all(
+        _is_quarter_turn(angle)
+        for angle in (stmt.x_exponent, stmt.z_exponent, stmt.axis_phase_exponent)
+    )
+
+
+def _is_clifford_gate(stmt: gate.stmts.Gate) -> bool:
+    if isinstance(stmt, _CLIFFORD_GATES):
+        return True
+    if isinstance(stmt, gate.stmts.RotationGate):
+        return _is_clifford_rotation(stmt)
+    if isinstance(stmt, gate.stmts.U3):
+        return _is_clifford_u3(stmt)
+    if isinstance(stmt, gate.stmts.PhasedXZ):
+        return _is_clifford_phased_xz(stmt)
+    return False
+
+
+class CliffordValidation(ValidationPass):
+    """Validate that a SQUIN kernel contains only Clifford gates."""
+
+    def name(self) -> str:
+        return "Clifford Validation"
+
+    def run(self, method: ir.Method) -> tuple[Any, list[ir.ValidationError]]:
+        errors: list[ir.ValidationError] = []
+
+        AggressiveUnroll(method.dialects).fixpoint(method)
+
+        for stmt in method.callable_region.walk():
+            if not isinstance(stmt, gate.stmts.Gate):
+                continue
+            if _is_clifford_gate(stmt):
+                continue
+
+            errors.append(
+                ir.ValidationError(
+                    stmt,
+                    f"Non-Clifford gate {type(stmt).__name__} is not allowed "
+                    "in a Clifford-only SQUIN kernel.",
+                )
+            )
+
+        return method, errors

--- a/src/bloqade/squin/analysis/validation/clifford.py
+++ b/src/bloqade/squin/analysis/validation/clifford.py
@@ -3,12 +3,14 @@ from __future__ import annotations
 from typing import Any
 
 import numpy as np
-from kirin import ir
+from kirin import ir, rewrite
+from kirin.analysis import CallGraph
 from kirin.dialects import py
 from kirin.validation import ValidationPass
 
 from bloqade.squin import gate
 from bloqade.rewrite.passes import AggressiveUnroll
+from bloqade.rewrite.passes.callgraph import ReplaceMethods
 from bloqade.squin.rewrite.U3_to_clifford import SquinU3ToClifford
 
 _CLIFFORD_GATES = (
@@ -74,6 +76,22 @@ def _is_clifford_gate(stmt: gate.stmts.Gate) -> bool:
     return False
 
 
+def _clone_call_graph(method: ir.Method) -> ir.Method:
+    cloned_methods = {}
+    call_graph = CallGraph(method)
+    methods = set(call_graph.edges.keys())
+    methods.update(sum(map(tuple, call_graph.defs.values()), ()))
+    methods.add(method)
+
+    for original_method in methods:
+        cloned_methods[original_method] = original_method.similar()
+
+    for cloned_method in cloned_methods.values():
+        rewrite.Walk(ReplaceMethods(cloned_methods)).rewrite(cloned_method.code)
+
+    return cloned_methods[method]
+
+
 class CliffordValidation(ValidationPass):
     """Validate that a SQUIN kernel contains only Clifford gates."""
 
@@ -84,10 +102,11 @@ class CliffordValidation(ValidationPass):
     def run(self, method: ir.Method) -> tuple[Any, list[ir.ValidationError]]:
         """Run Clifford-only validation for a SQUIN method."""
         errors: list[ir.ValidationError] = []
+        canonical_method = _clone_call_graph(method)
 
-        AggressiveUnroll(method.dialects).fixpoint(method)
+        AggressiveUnroll(canonical_method.dialects).fixpoint(canonical_method)
 
-        for stmt in method.callable_region.walk():
+        for stmt in canonical_method.callable_region.walk():
             if not isinstance(stmt, gate.stmts.Gate):
                 continue
             if _is_clifford_gate(stmt):

--- a/test/squin/validation/test_clifford_validation.py
+++ b/test/squin/validation/test_clifford_validation.py
@@ -10,8 +10,26 @@ from bloqade.squin.analysis.validation import CliffordValidation
 from bloqade.squin.analysis.validation.clifford import _constant_turn
 
 
+def _stmt_type_names(method):
+    return [type(stmt).__name__ for stmt in method.callable_region.walk()]
+
+
 def test_clifford_validation_name():
     assert CliffordValidation().name() == "Clifford Validation"
+
+
+def test_clifford_validation_does_not_mutate_kernel():
+    @squin.kernel
+    def main():
+        q = squin.qalloc(1)
+        squin.h(q[0])
+
+    before = _stmt_type_names(main)
+
+    _, errors = CliffordValidation().run(main)
+
+    assert len(errors) == 0
+    assert _stmt_type_names(main) == before
 
 
 def test_clifford_kernel_allowed():

--- a/test/squin/validation/test_clifford_validation.py
+++ b/test/squin/validation/test_clifford_validation.py
@@ -1,0 +1,80 @@
+import math
+
+import pytest
+from kirin.validation import ValidationSuite
+from kirin.ir.exception import ValidationErrorGroup
+
+from bloqade import squin
+from bloqade.squin.analysis.validation import CliffordValidation
+
+
+def test_clifford_kernel_allowed():
+    @squin.kernel
+    def main():
+        q = squin.qalloc(4)
+        squin.h(q[0])
+        squin.s(q[0])
+        squin.sqrt_x(q[1])
+        squin.sqrt_y_adj(q[1])
+        squin.cx(q[0], q[1])
+        squin.cy(q[1], q[2])
+        squin.cz(q[2], q[3])
+
+    _, errors = CliffordValidation().run(main)
+    assert len(errors) == 0
+
+
+def test_non_clifford_t_gate_rejected():
+    @squin.kernel
+    def main():
+        q = squin.qalloc(2)
+        squin.h(q[0])
+        squin.t(q[0])
+        squin.cx(q[0], q[1])
+
+    suite = ValidationSuite([CliffordValidation])
+    result = suite.validate(main)
+    assert result.error_count() == 1
+
+    with pytest.raises(ValidationErrorGroup):
+        result.raise_if_invalid()
+
+
+def test_quarter_turn_rotation_allowed():
+    @squin.kernel
+    def main():
+        q = squin.qalloc(3)
+        squin.rx(math.pi / 2, q[0])
+        squin.ry(math.pi, q[1])
+        squin.rz(3 * math.pi / 2, q[2])
+
+    _, errors = CliffordValidation().run(main)
+    assert len(errors) == 0
+
+
+def test_non_clifford_rotation_rejected():
+    @squin.kernel
+    def main():
+        q = squin.qalloc(1)
+        squin.rz(math.pi / 4, q[0])
+
+    suite = ValidationSuite([CliffordValidation])
+    result = suite.validate(main)
+    assert result.error_count() == 1
+
+    with pytest.raises(ValidationErrorGroup):
+        result.raise_if_invalid()
+
+
+def test_symbolic_rotation_rejected():
+    @squin.kernel
+    def main(angle: float):
+        q = squin.qalloc(1)
+        squin.rx(angle, q[0])
+
+    suite = ValidationSuite([CliffordValidation])
+    result = suite.validate(main)
+    assert result.error_count() == 1
+
+    with pytest.raises(ValidationErrorGroup):
+        result.raise_if_invalid()

--- a/test/squin/validation/test_clifford_validation.py
+++ b/test/squin/validation/test_clifford_validation.py
@@ -1,11 +1,17 @@
 import math
 
 import pytest
+from kirin.dialects import py
 from kirin.validation import ValidationSuite
 from kirin.ir.exception import ValidationErrorGroup
 
 from bloqade import squin
 from bloqade.squin.analysis.validation import CliffordValidation
+from bloqade.squin.analysis.validation.clifford import _constant_turn
+
+
+def test_clifford_validation_name():
+    assert CliffordValidation().name() == "Clifford Validation"
 
 
 def test_clifford_kernel_allowed():
@@ -78,3 +84,43 @@ def test_symbolic_rotation_rejected():
 
     with pytest.raises(ValidationErrorGroup):
         result.raise_if_invalid()
+
+
+def test_u3_clifford_gate_allowed():
+    @squin.kernel
+    def main():
+        q = squin.qalloc(1)
+        squin.u3(0.0, 0.0, math.pi / 2, q[0])
+
+    _, errors = CliffordValidation().run(main)
+    assert len(errors) == 0
+
+
+def test_phased_xz_quarter_turns_allowed():
+    @squin.kernel
+    def main():
+        q = squin.qalloc(1)
+        squin.phased_xz(math.pi / 2, math.pi, 0.0, q[0])
+
+    _, errors = CliffordValidation().run(main)
+    assert len(errors) == 0
+
+
+def test_phased_xz_non_quarter_turn_rejected():
+    @squin.kernel
+    def main():
+        q = squin.qalloc(1)
+        squin.phased_xz(math.pi / 4, 0.0, 0.0, q[0])
+
+    suite = ValidationSuite([CliffordValidation])
+    result = suite.validate(main)
+    assert result.error_count() == 1
+
+    with pytest.raises(ValidationErrorGroup):
+        result.raise_if_invalid()
+
+
+def test_non_numeric_constant_turn_rejected():
+    value = py.Constant(value="not numeric").result
+
+    assert _constant_turn(value) is None


### PR DESCRIPTION
## Summary
- add `CliffordValidation` for SQUIN kernels
- accept the existing Clifford gate set plus exact quarter-turn rotations/U3/phased-XZ cases
- reject non-Clifford gates such as `T`, non-quarter-turn rotations, and symbolic rotations
- add focused validation tests for direct pass usage and `ValidationSuite`

## Validation
- `python -m black src\bloqade\squin\analysis\validation\__init__.py src\bloqade\squin\analysis\validation\clifford.py test\squin\validation\test_clifford_validation.py`
- `python -m ruff check src\bloqade\squin\analysis\validation\__init__.py src\bloqade\squin\analysis\validation\clifford.py test\squin\validation\test_clifford_validation.py`
- `python -m pytest test\squin\validation\test_clifford_validation.py test\squin\validation\test_simple_nocloning.py test\stim\from_squin_validation\test_from_squin_validation.py -q`

AI assistance disclosure: AI assistance was used for repository navigation, implementation drafting, and validation planning. I reviewed the code and ran the tests above locally.

/claim #665