### PR TITLE
Emit squin if statements as Cirq classical controls

### DIFF
--- a/src/bloqade/cirq_utils/emit/__init__.py
+++ b/src/bloqade/cirq_utils/emit/__init__.py
@@ -1,3 +1,3 @@
 # NOTE: just to register methods
-from . import gate as gate, noise as noise, qubit as qubit
+from . import gate as gate, noise as noise, qubit as qubit, scf as scf
 from .base import emit_circuit as emit_circuit

--- a/src/bloqade/cirq_utils/emit/base.py
+++ b/src/bloqade/cirq_utils/emit/base.py
@@ -7,10 +7,12 @@ from kirin import ir, types, interp
 from kirin.emit import EmitABC, EmitFrame
 from kirin.interp import MethodTable, impl
 from kirin.dialects import py, func, ilist
+from kirin.ir.exception import ValidationErrorGroup
 from typing_extensions import Self
 
 from bloqade.squin import kernel
 from bloqade.rewrite.passes import AggressiveUnroll
+from bloqade.cirq_utils.emit.validation import CirqEmissionValidation
 
 
 def emit_circuit(
@@ -156,6 +158,13 @@ def emit_circuit(
     )
 
     AggressiveUnroll(mt_.dialects).fixpoint(mt_)
+    _, validation_errors = CirqEmissionValidation().run(mt_)
+    if validation_errors:
+        raise ValidationErrorGroup(
+            f"Cirq emission validation failed with {len(validation_errors)} error(s)",
+            errors=validation_errors,
+        )
+
     emitter.initialize()
     emitter.run(mt_)
     return emitter.circuit
@@ -165,6 +174,7 @@ def emit_circuit(
 class EmitCirqFrame(EmitFrame):
     qubit_index: int = 0
     qubits: Sequence[cirq.Qid] | None = None
+    measurement_keys: dict[ir.SSAValue, str] = field(default_factory=dict)
 
 
 def _default_kernel():

--- a/src/bloqade/cirq_utils/emit/classical_control.py
+++ b/src/bloqade/cirq_utils/emit/classical_control.py
@@ -1,0 +1,81 @@
+from dataclasses import dataclass
+
+import cirq
+import sympy
+from kirin import ir, interp
+from kirin.dialects import py
+
+from bloqade.qubit import stmts as qubit
+
+
+@dataclass(frozen=True)
+class MeasurementCondition:
+    measurement: ir.SSAValue
+    value: bool
+
+
+def _constant_value(value: ir.SSAValue):
+    if not isinstance(value, ir.ResultValue) or not isinstance(value.owner, py.Constant):
+        return None
+    return value.owner.value.unwrap()
+
+
+def _measurement_result(value: ir.SSAValue) -> ir.SSAValue | None:
+    if not isinstance(value, ir.ResultValue):
+        return None
+
+    owner = value.owner
+    if isinstance(owner, py.indexing.GetItem):
+        index = _constant_value(owner.index)
+        if index != 0:
+            return None
+
+        if isinstance(owner.obj, ir.ResultValue) and isinstance(
+            owner.obj.owner, qubit.Measure
+        ):
+            qubits = owner.obj.owner.qubits
+            if (
+                isinstance(qubits, ir.ResultValue)
+                and isinstance(qubits.owner, py.indexing.GetItem)
+            ):
+                return owner.obj
+            if (
+                hasattr(qubits, "owner")
+                and hasattr(qubits.owner, "values")
+                and len(qubits.owner.values) == 1
+            ):
+                return owner.obj
+
+    return None
+
+
+def get_measurement_condition(cond: ir.SSAValue) -> MeasurementCondition | None:
+    if not isinstance(cond, ir.ResultValue):
+        return None
+
+    owner = cond.owner
+    if isinstance(owner, py.cmp.Eq):
+        lhs_measurement = _measurement_result(owner.lhs)
+        rhs_value = _constant_value(owner.rhs)
+        if lhs_measurement is not None and rhs_value in (0, 1, False, True):
+            return MeasurementCondition(lhs_measurement, bool(rhs_value))
+
+        rhs_measurement = _measurement_result(owner.rhs)
+        lhs_value = _constant_value(owner.lhs)
+        if rhs_measurement is not None and lhs_value in (0, 1, False, True):
+            return MeasurementCondition(rhs_measurement, bool(lhs_value))
+
+    return None
+
+
+def cirq_condition_for_key(key: str, value: bool):
+    if value:
+        return key
+    return cirq.SympyCondition(sympy.Eq(sympy.Symbol(key), 0))
+
+
+def unsupported_condition_error() -> interp.exceptions.InterpreterError:
+    return interp.exceptions.InterpreterError(
+        "Cirq emission supports if statements only when the condition compares "
+        "one measurement result with True, False, 1, or 0."
+    )

--- a/src/bloqade/cirq_utils/emit/qubit.py
+++ b/src/bloqade/cirq_utils/emit/qubit.py
@@ -23,7 +23,10 @@ class EmitCirqQubitMethods(MethodTable):
         self, emit: EmitCirq, frame: EmitCirqFrame, stmt: qubit.Measure
     ):
         qbits = frame.get(stmt.qubits)
-        emit.circuit.append(cirq.measure(qbits), strategy=cirq.InsertStrategy.NEW)
+        measurement = cirq.measure(qbits)
+        emit.circuit.append(measurement, strategy=cirq.InsertStrategy.NEW)
+        measurement_keys = cirq.measurement_key_names(measurement)
+        frame.measurement_keys[stmt.result] = next(iter(measurement_keys))
         return (emit.void,)
 
     @impl(qubit.Reset)

--- a/src/bloqade/cirq_utils/emit/scf.py
+++ b/src/bloqade/cirq_utils/emit/scf.py
@@ -1,0 +1,53 @@
+import cirq
+from kirin import interp
+from kirin.dialects import scf
+
+from .base import EmitCirq, EmitCirqFrame
+from .classical_control import (
+    cirq_condition_for_key,
+    get_measurement_condition,
+    unsupported_condition_error,
+)
+
+
+@scf.dialect.register(key="emit.cirq")
+class EmitCirqScfMethods(interp.MethodTable):
+    @interp.impl(scf.IfElse)
+    def if_else(self, emit: EmitCirq, frame: EmitCirqFrame, stmt: scf.IfElse):
+        measurement_condition = get_measurement_condition(stmt.cond)
+        if measurement_condition is None:
+            raise unsupported_condition_error()
+
+        key = frame.measurement_keys.get(measurement_condition.measurement)
+        if key is None:
+            raise interp.exceptions.InterpreterError(
+                "Cirq if emission could not find a measurement key for the condition."
+            )
+
+        parent_circuit = emit.circuit
+        then_circuit = cirq.Circuit()
+        old_block = frame.current_block
+        old_stmt = frame.current_stmt
+
+        emit.circuit = then_circuit
+        try:
+            for block in stmt.then_body.blocks:
+                frame.current_block = block
+                for child in block.stmts:
+                    if isinstance(child, scf.Yield):
+                        continue
+                    frame.current_stmt = child
+                    child_results = emit.frame_eval(frame, child)
+                    if isinstance(child_results, tuple) and child_results:
+                        frame.set_values(child.results, child_results)
+        finally:
+            emit.circuit = parent_circuit
+            frame.current_block = old_block
+            frame.current_stmt = old_stmt
+
+        condition = cirq_condition_for_key(key, measurement_condition.value)
+        controlled_ops = [
+            op.with_classical_controls(condition) for op in then_circuit.all_operations()
+        ]
+        emit.circuit.append(controlled_ops, strategy=cirq.InsertStrategy.NEW)
+        return ()

--- a/src/bloqade/cirq_utils/emit/validation.py
+++ b/src/bloqade/cirq_utils/emit/validation.py
@@ -1,0 +1,131 @@
+from typing import Any
+
+from kirin import ir, interp
+from kirin.dialects import ilist, scf
+from kirin.lattice import EmptyLattice
+from kirin.analysis import Forward
+from kirin.validation import ValidationPass
+from kirin.analysis.forward import ForwardFrame
+
+from bloqade.squin import gate
+from bloqade.qubit import stmts as qubit
+
+from .classical_control import get_measurement_condition
+
+
+class _CirqEmissionValidationAnalysis(Forward[EmptyLattice]):
+    keys = ["cirq.emit.validation"]
+    lattice = EmptyLattice
+
+    def method_self(self, method: ir.Method) -> EmptyLattice:
+        return self.lattice.bottom()
+
+    def eval_fallback(
+        self, frame: ForwardFrame[EmptyLattice], node: ir.Statement
+    ) -> tuple[EmptyLattice, ...]:
+        return tuple(self.lattice.bottom() for _ in range(len(node.results)))
+
+
+def _body_stmts(region: ir.Region) -> list[ir.Statement]:
+    return list(region.stmts())
+
+
+def _has_empty_else(stmt: scf.IfElse) -> bool:
+    else_stmts = _body_stmts(stmt.else_body)
+    return len(else_stmts) == 0 or (
+        len(else_stmts) == 1 and isinstance(else_stmts[0], scf.Yield)
+    )
+
+
+def _validate_then_body(
+    analysis: _CirqEmissionValidationAnalysis, stmt: scf.IfElse
+) -> None:
+    body_stmts = [
+        child
+        for child in _body_stmts(stmt.then_body)
+        if not isinstance(child, scf.Yield)
+    ]
+    gate_stmts = [child for child in body_stmts if isinstance(child, gate.stmts.Gate)]
+
+    if len(gate_stmts) != 1:
+        analysis.add_validation_error(
+            stmt,
+            ir.ValidationError(
+                stmt,
+                "Cirq if emission requires the then body to contain exactly "
+                "one gate operation.",
+            ),
+        )
+
+    for child in body_stmts:
+        if isinstance(child, (gate.stmts.Gate, ilist.New)):
+            continue
+        analysis.add_validation_error(
+            stmt,
+            ir.ValidationError(
+                stmt,
+                "Cirq if emission supports only one gate operation in the then body.",
+            ),
+        )
+        break
+
+
+@scf.dialect.register(key="cirq.emit.validation")
+class _ScfMethods(interp.MethodTable):
+    @interp.impl(scf.IfElse)
+    def if_else(
+        self,
+        analysis: _CirqEmissionValidationAnalysis,
+        frame: ForwardFrame[EmptyLattice],
+        stmt: scf.IfElse,
+    ):
+        if get_measurement_condition(stmt.cond) is None:
+            analysis.add_validation_error(
+                stmt,
+                ir.ValidationError(
+                    stmt,
+                    "Cirq if emission supports conditions comparing one "
+                    "measurement result with True, False, 1, or 0.",
+                ),
+            )
+
+        if not _has_empty_else(stmt):
+            analysis.add_validation_error(
+                stmt,
+                ir.ValidationError(
+                    stmt,
+                    "Cirq if emission requires the else body to be empty.",
+                ),
+            )
+
+        _validate_then_body(analysis, stmt)
+
+        for child in stmt.walk(include_self=False):
+            if isinstance(child, scf.IfElse):
+                analysis.add_validation_error(
+                    stmt,
+                    ir.ValidationError(
+                        stmt,
+                        "Nested if statements are not supported by Cirq emission.",
+                    ),
+                )
+                break
+            if isinstance(child, (qubit.Measure, qubit.Reset, qubit.New)):
+                analysis.add_validation_error(
+                    stmt,
+                    ir.ValidationError(
+                        stmt,
+                        "Cirq if emission supports only gate operations in the then body.",
+                    ),
+                )
+                break
+
+
+class CirqEmissionValidation(ValidationPass):
+    def name(self) -> str:
+        return "Cirq Emission Validation"
+
+    def run(self, method: ir.Method) -> tuple[Any, list[ir.ValidationError]]:
+        analysis = _CirqEmissionValidationAnalysis(method.dialects)
+        frame, _ = analysis.run(method)
+        return frame, analysis.get_validation_errors()

--- a/test/cirq_utils/test_classical_control.py
+++ b/test/cirq_utils/test_classical_control.py
@@ -1,0 +1,66 @@
+import cirq
+import pytest
+from kirin.ir.exception import ValidationErrorGroup
+
+from bloqade import squin
+from bloqade.cirq_utils import emit_circuit
+
+
+def test_emit_measurement_equal_one_as_classical_control():
+    @squin.kernel
+    def main():
+        q = squin.qalloc(2)
+        m = squin.measure(q[0])
+        if m == 1:
+            squin.x(q[1])
+
+    circuit = emit_circuit(main)
+    ops = list(circuit.all_operations())
+
+    assert len(ops) == 2
+    assert ops[0] == cirq.measure(cirq.LineQubit(0))
+    assert isinstance(ops[1], cirq.ClassicallyControlledOperation)
+    assert ops[1].sub_operation == cirq.X(cirq.LineQubit(1))
+
+
+def test_emit_measurement_equal_zero_as_classical_control():
+    @squin.kernel
+    def main():
+        q = squin.qalloc(2)
+        m = squin.measure(q[0])
+        if m == 0:
+            squin.x(q[1])
+
+    circuit = emit_circuit(main)
+    ops = list(circuit.all_operations())
+
+    assert len(ops) == 2
+    assert isinstance(ops[1], cirq.ClassicallyControlledOperation)
+    assert ops[1].sub_operation == cirq.X(cirq.LineQubit(1))
+
+
+def test_rejects_non_empty_else_body():
+    @squin.kernel
+    def main():
+        q = squin.qalloc(2)
+        m = squin.measure(q[0])
+        if m == 1:
+            squin.x(q[1])
+        else:
+            squin.z(q[1])
+
+    with pytest.raises(ValidationErrorGroup, match="else body"):
+        emit_circuit(main)
+
+
+def test_rejects_multiple_then_body_gates():
+    @squin.kernel
+    def main():
+        q = squin.qalloc(2)
+        m = squin.measure(q[0])
+        if m == 1:
+            squin.x(q[1])
+            squin.z(q[1])
+
+    with pytest.raises(ValidationErrorGroup, match="exactly one gate"):
+        emit_circuit(main)


### PR DESCRIPTION
﻿## Summary
- emit supported squin `if` statements as Cirq classically controlled operations
- validate the supported shape before emission: one measurement compared with `True`, `False`, `1`, or `0`, empty `else`, and exactly one gate operation in the `then` body
- track Cirq measurement keys during emission so the control condition can reference the emitted measurement

Closes #408

## Validation
- `git diff --check`
- Python syntax check for the touched emitter and test files

I could not run the Cirq pytest subset locally because this workspace venv does not currently have `cirq-core` available and pip is configured without an available local wheel.

## AI disclosure
This contribution was developed with assistance from OpenAI Codex.
