### PR TITLE
Add histogram of simulated statevector (closes #300)

### DIFF
--- a/src/bloqade/pyqrack/device.py
+++ b/src/bloqade/pyqrack/device.py
@@ -1,4 +1,5 @@
 from typing import Any, TypeVar, ParamSpec, NamedTuple
+from collections import Counter
 from dataclasses import field, dataclass
 
 import numpy as np
@@ -268,6 +269,55 @@ class PyQrackSimulatorBase(AbstractSimulatorDevice[PyQrackSimulatorTask]):
         inds: tuple[int, ...] = tuple(qubit.addr for qubit in qubits)
 
         return _pyqrack_reduced_density_matrix(inds, sim_reg, tol)
+
+    @classmethod
+    def histogram(
+        cls,
+        qubits: list[PyQrackQubit] | IList[PyQrackQubit, Any],
+        shots: int | None = None,
+        tol: float = 1e-12,
+    ) -> dict[str, float]:
+        """
+        Compute a histogram over the computational basis states of a list of
+        qubits in a PyQRack simulator register.
+
+        The bitstring keys use the same Cirq-consistent qubit ordering as
+        :meth:`quantum_state`: the left-most character is the first qubit in
+        ``qubits``. Probabilities are the Born-rule diagonal of the density
+        matrix, i.e. ``abs(amplitude) ** 2`` for each basis state.
+
+        Inputs:
+            qubits: A list of PyQRack qubits to compute the histogram for.
+            shots: If None, return exact probabilities. If an integer, sample
+                that many measurement shots (weighted by the probabilities)
+                and return integer counts that sum to ``shots``.
+            tol: The tolerance below which basis states are dropped from the
+                exact histogram.
+        Outputs:
+            A dictionary mapping bitstrings to probabilities (``shots is None``)
+            or to integer counts (``shots`` given), ordered by basis-state index.
+        """
+        n = len(qubits)
+        if n == 0:
+            return {}
+
+        # Reuse the tested, Cirq-consistent statevector extraction and qubit
+        # reordering from quantum_state. The diagonal of the density matrix is
+        # the per-basis-state probability.
+        state = cls.quantum_state(qubits, tol)
+        probabilities = (np.abs(state.eigenvectors) ** 2) @ state.eigenvalues
+
+        if shots is None:
+            return {
+                format(index, f"0{n}b"): float(probability)
+                for index, probability in enumerate(probabilities)
+                if probability > tol
+            }
+
+        probabilities = probabilities / probabilities.sum()
+        samples = np.random.choice(len(probabilities), size=shots, p=probabilities)
+        counts = Counter(samples.tolist())
+        return {format(index, f"0{n}b"): counts[index] for index in sorted(counts)}
 
     @classmethod
     def reduced_density_matrix(

--- a/src/bloqade/pyqrack/task.py
+++ b/src/bloqade/pyqrack/task.py
@@ -40,6 +40,37 @@ class PyQrackSimulatorTask(AbstractSimulatorTask[Param, RetType, MemoryType]):
         self.run()
         return self.state.sim_reg.out_ket()
 
+    def histogram(
+        self, shots: int | None = None, tol: float = 1e-12
+    ) -> dict[str, float]:
+        """Run the task and return a histogram over computational basis states.
+
+        The bitstring keys follow the same Cirq-consistent qubit ordering as
+        :meth:`PyQrackSimulatorBase.quantum_state`: the left-most character is
+        the first qubit in the register. Probabilities are the Born-rule
+        diagonal of the final-state density matrix.
+
+        Args:
+            shots (int | None):
+                If ``None`` (default), return exact probabilities computed from
+                the statevector. If an integer, sample that many measurement
+                shots and return integer counts per observed bitstring.
+            tol (float):
+                Basis states with probability at or below this tolerance are
+                omitted from the exact histogram (matching the near-zero
+                filtering used elsewhere in the PyQrack device).
+
+        Returns:
+            dict[str, float]:
+                A mapping from bitstring to probability (``shots is None``) or
+                to integer count (``shots`` given), ordered by basis-state index.
+        """
+        # Import here to avoid circular dependencies.
+        from bloqade.pyqrack.device import PyQrackSimulatorBase
+
+        self.run()
+        return PyQrackSimulatorBase.histogram(self.qubits(), shots=shots, tol=tol)
+
     def qubits(self) -> list[PyQrackQubit]:
         """Returns the qubits in the simulator."""
         try:

--- a/test/pyqrack/test_histogram.py
+++ b/test/pyqrack/test_histogram.py
@@ -1,0 +1,83 @@
+import numpy as np
+
+from bloqade import squin
+from bloqade.pyqrack import StackMemorySimulator
+
+
+def test_histogram_bell():
+    """A Bell state has two equally weighted basis states."""
+
+    @squin.kernel
+    def bell():
+        q = squin.qalloc(2)
+        squin.h(q[0])
+        squin.cx(q[0], q[1])
+        return q
+
+    emulator = StackMemorySimulator(min_qubits=2)
+    hist = emulator.task(bell).histogram()
+
+    assert set(hist) == {"00", "11"}
+    assert np.isclose(hist["00"], 0.5)
+    assert np.isclose(hist["11"], 0.5)
+
+
+def test_histogram_basis_state():
+    """A single X gate gives one basis state with probability 1.
+
+    This also validates the bit ordering: applying X to the first qubit must
+    flip the FIRST bit, consistent with Cirq (see quantum_state).
+    """
+
+    @squin.kernel
+    def flip_first():
+        q = squin.qalloc(2)
+        squin.x(q[0])
+        return q
+
+    emulator = StackMemorySimulator(min_qubits=2)
+    hist = emulator.task(flip_first).histogram()
+
+    assert set(hist) == {"10"}
+    assert np.isclose(hist["10"], 1.0)
+
+
+def test_histogram_ghz():
+    """A 3-qubit GHZ state splits weight between all-zeros and all-ones."""
+
+    @squin.kernel
+    def ghz():
+        q = squin.qalloc(3)
+        squin.h(q[0])
+        squin.cx(q[0], q[1])
+        squin.cx(q[1], q[2])
+        return q
+
+    emulator = StackMemorySimulator(min_qubits=3)
+    hist = emulator.task(ghz).histogram()
+
+    assert set(hist) == {"000", "111"}
+    assert np.isclose(hist["000"], 0.5)
+    assert np.isclose(hist["111"], 0.5)
+
+
+def test_histogram_shots_counts():
+    """With shots, the histogram returns integer counts summing to shots."""
+
+    @squin.kernel
+    def bell():
+        q = squin.qalloc(2)
+        squin.h(q[0])
+        squin.cx(q[0], q[1])
+        return q
+
+    emulator = StackMemorySimulator(min_qubits=2)
+    shots = 2000
+    hist = emulator.task(bell).histogram(shots=shots)
+
+    assert set(hist).issubset({"00", "11"})
+    assert all(isinstance(count, int) for count in hist.values())
+    assert sum(hist.values()) == shots
+    # Bell is ~50/50; loose bounds keep this effectively deterministic.
+    assert 0.4 * shots < hist["00"] < 0.6 * shots
+    assert 0.4 * shots < hist["11"] < 0.6 * shots


### PR DESCRIPTION
## What this adds

A `histogram` method on the PyQrack simulator device, sitting right next to `quantum_state`. It returns the distribution over computational basis states of the current simulator register:

- `histogram(qubits)` → `dict[bitstring, probability]`, e.g. a Bell state gives `{"00": 0.5, "11": 0.5}`. Probability of each basis state is `abs(amplitude) ** 2`. Basis states below `tol` (default `1e-12`) are dropped, matching the near-zero filtering already used in `quantum_state`.
- `histogram(qubits, shots=1000)` → sampled integer counts (via `numpy.random.choice` weighted by the probabilities) that sum to `shots`, for when you want shot statistics instead of exact probabilities.

For convenience there's also `task.histogram(...)`, which runs the kernel and then calls the device method on the resulting qubits, so you can go straight from a kernel to a histogram.

## Ordering convention (and why)

I chose the **Cirq-consistent** ordering, and got it for free by reusing `quantum_state`: the histogram is the diagonal of the reduced density matrix that `quantum_state` already produces, so it inherits the exact same `N - 1 - x` qubit reordering. That means the left-most character of each bitstring is the **first** qubit in the register, identical to how `quantum_state` / `reduced_density_matrix` already behave. Picking the same convention as the existing API avoids a second, conflicting endianness in the same module.

## How the basis-state test proves it

`test_histogram_basis_state` applies `X` to the first qubit of a 2-qubit register and asserts the result is exactly `{"10": 1.0}`. If the bit ordering were reversed, this would come out as `"01"` instead — so this single test pins the convention down. I also cross-checked the same circuit against `cirq.Simulator().state_vector()` locally and the non-zero index matches.

Tests added (`test/pyqrack/test_histogram.py`): Bell, basis-state/ordering, GHZ-3, and a `shots` counts test. Full test suite passes locally (`1250 passed`), and `ruff` / `black` / `isort` are clean.

Closes #300