### PR TITLE
Ignore annotate statements on the PyQrack simulator (closes #628)

### DIFF
--- a/src/bloqade/pyqrack/__init__.py
+++ b/src/bloqade/pyqrack/__init__.py
@@ -15,7 +15,12 @@ from .task import PyQrackSimulatorTask as PyQrackSimulatorTask
 # NOTE: The following import is for registering the method tables
 from .noise import native as native
 from .qasm2 import uop as uop, core as core, glob as glob, parallel as parallel
-from .squin import gate as gate, noise as noise, qubit as qubit
+from .squin import (
+    gate as gate,
+    noise as noise,
+    qubit as qubit,
+    annotate as annotate,
+)
 from .device import (
     StackMemorySimulator as StackMemorySimulator,
     DynamicMemorySimulator as DynamicMemorySimulator,

--- a/src/bloqade/pyqrack/squin/annotate.py
+++ b/src/bloqade/pyqrack/squin/annotate.py
@@ -1,0 +1,33 @@
+from kirin import interp
+
+from bloqade.pyqrack.base import PyQrackInterpreter
+from bloqade.decoders.dialects import annotate
+
+
+@annotate.dialect.register(key="pyqrack")
+class PyQrackAnnotateMethods(interp.MethodTable):
+    """No-op handlers for the ``annotate`` dialect on the PyQrack simulator.
+
+    ``annotate`` statements (detectors, observables) are decoder annotations
+    that have no effect on state-vector simulation. Registering these handlers
+    lets a kernel containing them run on PyQrack instead of raising
+    ``Missing implementation``; the statements are simply ignored.
+    """
+
+    @interp.impl(annotate.stmts.SetDetector)
+    def set_detector(
+        self,
+        interp: PyQrackInterpreter,
+        frame: interp.Frame,
+        stmt: annotate.stmts.SetDetector,
+    ):
+        return (None,)
+
+    @interp.impl(annotate.stmts.SetObservable)
+    def set_observable(
+        self,
+        interp: PyQrackInterpreter,
+        frame: interp.Frame,
+        stmt: annotate.stmts.SetObservable,
+    ):
+        return (None,)

--- a/test/pyqrack/test_annotate.py
+++ b/test/pyqrack/test_annotate.py
@@ -1,0 +1,26 @@
+from bloqade import squin
+from bloqade.pyqrack import StackMemorySimulator
+
+
+def test_annotate_statements_are_ignored():
+    """A kernel containing `annotate` statements runs on PyQrack.
+
+    `set_detector` / `set_observable` are decoder annotations with no effect on
+    state-vector simulation. They used to raise `Missing implementation`; now
+    they are skipped as no-ops so the kernel executes (see issue #628).
+    """
+
+    @squin.kernel
+    def with_annotations():
+        q = squin.qalloc(2)
+        squin.h(q[0])
+        squin.cx(q[0], q[1])
+        ms = squin.broadcast.measure(q)
+        squin.set_detector([ms[0], ms[1]], coordinates=(0.0, 0.0))
+        squin.set_observable([ms[0]])
+        return q
+
+    sim = StackMemorySimulator(min_qubits=2)
+    qubits = sim.run(with_annotations)
+
+    assert len(qubits) == 2


### PR DESCRIPTION
## What this adds

Following the conclusion of #616, this lets a kernel that contains `annotate` statements (`set_detector`, `set_observable`) execute on the **PyQrack** simulator instead of crashing.

Previously, running such a kernel raised:

```
NotImplementedError: Missing implementation for SetDetector
```

because the `annotate` dialect has no interpreter handlers for PyQrack. This registers a small method table (`PyQrackAnnotateMethods`) with no-op handlers for `SetDetector` and `SetObservable`. They are decoder annotations with no effect on state-vector simulation, so the interpreter simply ignores them and continues.

## Scope note (Cirq)

The issue title mentions Cirq as well. I looked into it and the Cirq path is blocked by a **separate, pre-existing limitation** that is independent of `annotate`: the Cirq emitter's `GetItem` handler explicitly does not support indexing into individual statement results (`src/bloqade/cirq_utils/emit/base.py`, "no support for indexing into single statements in cirq"). Because `set_detector`/`set_observable` take indexed measurement results (`ms[0]`, `ms[1]`), emission fails while building their argument list, before any annotate handler is reached. Making that work requires representing measurement records as indexable values in the emitter, which is a larger change than a no-op handler. I kept this PR focused on the PyQrack fix; happy to open a follow-up for the Cirq side if you'd like.

## Test

`test/pyqrack/test_annotate.py` runs a kernel with both `set_detector` and `set_observable` on `StackMemorySimulator` and asserts it executes. Full test suite passes locally (`1247 passed`); `ruff` / `black` / `isort` are clean.

Closes #628