### PR TITLE
Add CliffordValidation pass for squin kernels (closes #665)

### DIFF
--- a/src/bloqade/analysis/validation/clifford/__init__.py
+++ b/src/bloqade/analysis/validation/clifford/__init__.py
@@ -1,0 +1,4 @@
+from .validation import (
+    CliffordValidation as CliffordValidation,
+    _CliffordAnalysis as _CliffordAnalysis,
+)

--- a/src/bloqade/analysis/validation/clifford/validation.py
+++ b/src/bloqade/analysis/validation/clifford/validation.py
@@ -1,0 +1,41 @@
+from typing import Any
+
+from kirin import ir
+from kirin.lattice import EmptyLattice
+from kirin.analysis import Forward
+from kirin.validation import ValidationPass
+from kirin.analysis.forward import ForwardFrame
+
+
+class _CliffordAnalysis(Forward[EmptyLattice]):
+    """Flags Squin gates that cannot be represented as Clifford gates in Stim."""
+
+    keys = ("validate.clifford",)
+    lattice = EmptyLattice
+
+    def method_self(self, method: ir.Method) -> EmptyLattice:
+        return self.lattice.bottom()
+
+    def eval_fallback(
+        self, frame: ForwardFrame[EmptyLattice], node: ir.Statement
+    ) -> tuple[EmptyLattice, ...]:
+        return tuple(self.lattice.bottom() for _ in range(len(node.results)))
+
+    def collect_errors(self, stmt: ir.Statement) -> None:
+        self.add_validation_error(
+            stmt,
+            ir.ValidationError(
+                stmt,
+                f"Gate {stmt.name.upper()} is not a Clifford gate.",
+            ),
+        )
+
+
+class CliffordValidation(ValidationPass):
+    def name(self) -> str:
+        return "Clifford Validation"
+
+    def run(self, method: ir.Method) -> tuple[Any, list[ir.ValidationError]]:
+        analysis = _CliffordAnalysis(method.dialects)
+        frame, _ = analysis.run(method)
+        return frame, analysis.get_validation_errors()

--- a/src/bloqade/squin/__init__.py
+++ b/src/bloqade/squin/__init__.py
@@ -56,6 +56,9 @@ from .analysis.fidelity import impls as impls
 from .analysis.validation.simple_nocloning import (  # noqa: F401
     impls as simple_nocloning_impls,
 )
+from .analysis.validation.clifford import (  # noqa: F401
+    impls as clifford_impls,
+)
 
 # NOTE: it's important to keep these imports here since they import squin.kernel
 # we skip isort here

--- a/src/bloqade/squin/analysis/validation/__init__.py
+++ b/src/bloqade/squin/analysis/validation/__init__.py
@@ -1,0 +1,3 @@
+from bloqade.analysis.validation.clifford import (
+    CliffordValidation as CliffordValidation,
+)

--- a/src/bloqade/squin/analysis/validation/clifford/impls.py
+++ b/src/bloqade/squin/analysis/validation/clifford/impls.py
@@ -1,0 +1,55 @@
+import math
+
+from kirin import interp
+from kirin.lattice import EmptyLattice
+from kirin.analysis import ForwardFrame
+
+from bloqade.squin import gate
+from bloqade.squin.rewrite import SquinU3ToClifford
+from bloqade.analysis.validation.clifford import _CliffordAnalysis
+
+# Reused as the single source of truth for which rotation/U3 angles the
+# squin -> stim pipeline can turn into Clifford gates.
+_u3_to_clifford = SquinU3ToClifford()
+
+
+def _rotation_is_clifford(stmt: gate.stmts.RotationGate) -> bool:
+    angle = _u3_to_clifford.get_constant(stmt.angle)
+    if angle is None:
+        return False
+    return _u3_to_clifford.resolve_angle(angle * math.tau) is not None
+
+
+@gate.dialect.register(key="validate.clifford")
+class _GateMethods(interp.MethodTable):
+    @interp.impl(gate.stmts.T)
+    @interp.impl(gate.stmts.PhasedXZ)
+    def non_clifford_gate(
+        self,
+        interp_: _CliffordAnalysis,
+        frame: ForwardFrame[EmptyLattice],
+        stmt: gate.stmts.Gate,
+    ):
+        interp_.collect_errors(stmt)
+
+    @interp.impl(gate.stmts.Rx)
+    @interp.impl(gate.stmts.Ry)
+    @interp.impl(gate.stmts.Rz)
+    def rotation_gate(
+        self,
+        interp_: _CliffordAnalysis,
+        frame: ForwardFrame[EmptyLattice],
+        stmt: gate.stmts.RotationGate,
+    ):
+        if not _rotation_is_clifford(stmt):
+            interp_.collect_errors(stmt)
+
+    @interp.impl(gate.stmts.U3)
+    def u3_gate(
+        self,
+        interp_: _CliffordAnalysis,
+        frame: ForwardFrame[EmptyLattice],
+        stmt: gate.stmts.U3,
+    ):
+        if not _u3_to_clifford.decompose_U3_gates(stmt):
+            interp_.collect_errors(stmt)

--- a/test/squin/validation/test_clifford.py
+++ b/test/squin/validation/test_clifford.py
@@ -1,0 +1,135 @@
+import math
+
+import pytest
+from kirin.validation import ValidationSuite
+from kirin.ir.exception import ValidationErrorGroup
+
+from bloqade import squin
+from bloqade.rewrite.passes import AggressiveUnroll
+from bloqade.stim.passes.flatten import Flatten
+from bloqade.squin.analysis.validation import CliffordValidation
+
+
+def _validate(kernel):
+    AggressiveUnroll(kernel.dialects).fixpoint(kernel)
+    _, errors = CliffordValidation().run(kernel)
+    return errors
+
+
+def test_clifford_kernel_passes():
+    @squin.kernel
+    def main():
+        q = squin.qalloc(4)
+        squin.h(q[0])
+        for i in range(3):
+            squin.cx(q[i], q[i + 1])
+
+    assert len(_validate(main)) == 0
+
+
+def test_named_clifford_gates_pass():
+    @squin.kernel
+    def main():
+        q = squin.qalloc(2)
+        squin.x(q[0])
+        squin.y(q[0])
+        squin.z(q[0])
+        squin.h(q[0])
+        squin.s(q[0])
+        squin.sqrt_x(q[0])
+        squin.sqrt_y(q[0])
+        squin.cx(q[0], q[1])
+        squin.cy(q[0], q[1])
+        squin.cz(q[0], q[1])
+
+    assert len(_validate(main)) == 0
+
+
+def test_t_gate_fails():
+    @squin.kernel
+    def main():
+        q = squin.qalloc(4)
+        squin.h(q[0])
+        for i in range(3):
+            squin.t(q[i])
+            squin.cx(q[i], q[i + 1])
+
+    assert len(_validate(main)) == 3
+
+
+def test_clifford_angle_rotations_pass():
+    @squin.kernel
+    def main():
+        q = squin.qalloc(1)
+        squin.rx(math.pi / 2, q[0])
+        squin.ry(math.pi, q[0])
+        squin.rz(3 * math.pi / 2, q[0])
+
+    assert len(_validate(main)) == 0
+
+
+def test_non_clifford_angle_rotation_fails():
+    @squin.kernel
+    def main():
+        q = squin.qalloc(1)
+        squin.rz(0.1, q[0])
+
+    assert len(_validate(main)) == 1
+
+
+def test_clifford_u3_passes():
+    @squin.kernel
+    def main():
+        q = squin.qalloc(1)
+        squin.u3(math.pi / 2, 0.0, math.pi, q[0])
+
+    assert len(_validate(main)) == 0
+
+
+def test_non_clifford_u3_fails():
+    @squin.kernel
+    def main():
+        q = squin.qalloc(1)
+        squin.u3(0.1, 0.2, 0.3, q[0])
+
+    assert len(_validate(main)) == 1
+
+
+def test_phased_xz_fails():
+    @squin.kernel
+    def main():
+        q = squin.qalloc(1)
+        squin.phased_xz(0.25, 0.5, 0.0, q[0])
+
+    assert len(_validate(main)) == 1
+
+
+def test_matches_squin_to_stim_pipeline():
+    # Mirrors how SquinToStimPass uses validation: Flatten first, then validate.
+    @squin.kernel
+    def main():
+        q = squin.qalloc(4)
+        squin.h(q[0])
+        for i in range(3):
+            squin.t(q[i])
+            squin.cx(q[i], q[i + 1])
+
+    Flatten(dialects=main.dialects).fixpoint(main)
+    _, errors = CliffordValidation().run(main)
+    assert len(errors) == 3
+
+
+def test_validation_suite_raises():
+    @squin.kernel
+    def main():
+        q = squin.qalloc(2)
+        squin.t(q[0])
+        squin.cx(q[0], q[1])
+
+    AggressiveUnroll(main.dialects).fixpoint(main)
+
+    result = ValidationSuite([CliffordValidation]).validate(main)
+    assert result.error_count() == 1
+
+    with pytest.raises(ValidationErrorGroup):
+        result.raise_if_invalid()


### PR DESCRIPTION
Closes #665

## Summary

Adds a `CliffordValidation` pass that flags Squin gates which cannot be represented as Clifford gates in Stim, so the squin→stim rewrite (#664) cannot let non-Clifford operations slip through undetected.

```python
from bloqade import squin
from bloqade.squin.analysis.validation import CliffordValidation

_, errors = CliffordValidation().run(flattened_kernel)
```

## Gate classification (grounded in the stim dialect)

The stim gate dialect already partitions gates by Clifford-ness, which I used as the source of truth:
- Clifford (`clifford_1q.py` / `clifford_2q.py`): `X, Y, Z, H, S, SqrtX, SqrtY, CX, CY, CZ` → accepted
- `non_clifford.py`: `T, Rx, Ry, Rz, U3` → rejected
- `PhasedXZ` (not representable in the stim dialect) → rejected

`Rx/Ry/Rz/U3` are accepted **only** when their angle is a compile-time constant multiple of π/2, because `SquinToStimPass` runs `SquinU3ToClifford` (which converts exactly those) before emission. To avoid duplicating that logic, the pass **reuses `SquinU3ToClifford`** as the oracle for which rotations/U3 are convertible. Symbolic or non-quarter-turn angles, and `T`/`PhasedXZ`, are rejected.

## Design

- Mirrors the existing validation passes: a `Forward[EmptyLattice]` analysis (`_CliffordAnalysis`) with a `gate.dialect` method table, plus a `CliffordValidation(ValidationPass)` whose `run()` returns `(frame, errors)` as required by `kirin.validation.ValidationPass` and `ValidationSuite`.
- Core pass under `src/bloqade/analysis/validation/clifford/`, squin method table under `src/bloqade/squin/analysis/validation/clifford/`, re-exported from `bloqade.squin.analysis.validation` (same split as `simple_nocloning`).
- The pass is **read-only** — it performs no rewriting or unrolling. Like `FlatKernelNoCloningValidation` and `StimFromSquinValidation`, it operates on a flattened kernel; the caller flattens (as `SquinToStimPass` already does with `Flatten` before validating).

## Tests

`test/squin/validation/test_clifford.py` (10 tests): named Clifford gates pass; `T`, non-quarter rotations, non-Clifford `U3`, and `PhasedXZ` fail; quarter-turn rotations and Clifford `U3` pass; `ValidationSuite` integration; and one test that mirrors the real `SquinToStimPass` flow (`Flatten` → validate).

### AI disclosure

I used an Claude as an assistant while working on this, mainly for scaffolding the files and tests and as a sounding board. The approach was driven by reading the existing code: the gate classification comes from the stim dialect's `clifford_*` / `non_clifford` split, the rotation/U3 handling reuses `SquinU3ToClifford`, and the read-only, flatten-first design follows the existing validation passes. I reviewed and tested everything against the codebase.