### PR TITLE
Add RemoveEmptyArgGates pass for empty qubit-list operations (closes #516)

### DIFF
--- a/src/bloqade/rewrite/passes/__init__.py
+++ b/src/bloqade/rewrite/passes/__init__.py
@@ -5,3 +5,4 @@ from .callgraph import (
 )
 from .aggressive_unroll import AggressiveUnroll as AggressiveUnroll
 from .canonicalize_ilist import CanonicalizeIList as CanonicalizeIList
+from .remove_empty_arg_gates import RemoveEmptyArgGates as RemoveEmptyArgGates

--- a/src/bloqade/rewrite/passes/remove_empty_arg_gates.py
+++ b/src/bloqade/rewrite/passes/remove_empty_arg_gates.py
@@ -1,0 +1,32 @@
+from dataclasses import dataclass
+
+from kirin import ir, passes
+from kirin.rewrite import Walk, Chain, Fixpoint, DeadCodeElimination
+from kirin.rewrite.abc import RewriteResult
+
+from bloqade.rewrite.rules.remove_empty_gates import (
+    RemoveEmptyGate,
+    RemoveEmptyGateCall,
+)
+
+from .callgraph import CallGraphPass
+
+
+@dataclass
+class RemoveEmptyArgGates(passes.Pass):
+    """Remove squin gates, noise channels and measurements applied to empty qubit lists.
+
+    A statement (or stdlib wrapper call) acting on a compile-time empty qubit list
+    is a no-op and is removed. Dead code elimination then cleans up any functions
+    and constants left unused.
+    """
+
+    def unsafe_run(self, mt: ir.Method) -> RewriteResult:
+        result = CallGraphPass(
+            dialects=self.dialects,
+            rule=Walk(Chain(RemoveEmptyGate(), RemoveEmptyGateCall())),
+            no_raise=self.no_raise,
+        ).unsafe_run(mt)
+
+        result = Fixpoint(Walk(DeadCodeElimination())).rewrite(mt.code).join(result)
+        return result

--- a/src/bloqade/rewrite/rules/__init__.py
+++ b/src/bloqade/rewrite/rules/__init__.py
@@ -1,1 +1,5 @@
 from .split_ifs import LiftThenBody as LiftThenBody, SplitIfStmts as SplitIfStmts
+from .remove_empty_gates import (
+    RemoveEmptyGate as RemoveEmptyGate,
+    RemoveEmptyGateCall as RemoveEmptyGateCall,
+)

--- a/src/bloqade/rewrite/rules/remove_empty_gates.py
+++ b/src/bloqade/rewrite/rules/remove_empty_gates.py
@@ -1,0 +1,77 @@
+from kirin import ir, types
+from kirin.ir import traits
+from kirin.dialects import func, ilist
+from kirin.rewrite.abc import RewriteRule, RewriteResult
+from kirin.dialects.func.stmts import Invoke
+
+from bloqade.squin import gate, noise
+from bloqade.qubit import stmts as qubit_stmts
+
+# Statements that apply an operation to a list of qubits. Applying any of them to
+# an empty list is a no-op.
+QubitOp = (
+    gate.stmts.Gate,
+    noise.stmts.NoiseChannel,
+    qubit_stmts.Measure,
+    qubit_stmts.Reset,
+)
+
+
+def _is_empty_ilist(value: ir.SSAValue) -> bool:
+    t = value.type
+    if not (isinstance(t, types.Generic) and t.is_subseteq(ilist.IListType)):
+        return False
+    _, length = t.vars
+    return isinstance(length, types.Literal) and length.data == 0
+
+
+def _operates_on_empty_qubits(stmt: ir.Statement) -> bool:
+    args = [
+        getattr(stmt, name)
+        for name in ("qubits", "controls", "targets")
+        if hasattr(stmt, name)
+    ]
+    return bool(args) and all(_is_empty_ilist(arg) for arg in args)
+
+
+def _is_qubit_op_wrapper(method: ir.Method) -> bool:
+    """True if the only effect of the method is applying qubit ops to qubit lists.
+
+    Such a method is a no-op when all of its qubit-list arguments are empty.
+    """
+    for stmt in method.callable_region.walk():
+        if isinstance(stmt, (func.Function, func.Return, QubitOp)):
+            continue
+        if stmt.has_trait(traits.Pure):
+            continue
+        if isinstance(stmt, Invoke) and _is_qubit_op_wrapper(stmt.callee):
+            continue
+        return False
+    return True
+
+
+class RemoveEmptyGate(RewriteRule):
+    """Remove gate, noise and measurement statements applied to empty qubit lists."""
+
+    def rewrite_Statement(self, node: ir.Statement) -> RewriteResult:
+        if not isinstance(node, QubitOp) or not _operates_on_empty_qubits(node):
+            return RewriteResult()
+        if any(result.uses for result in node.results):
+            return RewriteResult()
+        node.delete()
+        return RewriteResult(has_done_something=True)
+
+
+class RemoveEmptyGateCall(RewriteRule):
+    """Remove invocations of qubit-op wrappers (e.g. broadcast gates) on empty lists."""
+
+    def rewrite_Statement(self, node: ir.Statement) -> RewriteResult:
+        if not isinstance(node, Invoke) or any(result.uses for result in node.results):
+            return RewriteResult()
+
+        qubit_args = [arg for arg in node.inputs if _is_empty_ilist(arg)]
+        if not qubit_args or not _is_qubit_op_wrapper(node.callee):
+            return RewriteResult()
+
+        node.delete()
+        return RewriteResult(has_done_something=True)

--- a/test/squin/passes/test_remove_empty_arg_gates.py
+++ b/test/squin/passes/test_remove_empty_arg_gates.py
@@ -1,0 +1,91 @@
+from kirin.dialects.func.stmts import Invoke
+
+from bloqade import squin
+from bloqade.rewrite.passes import RemoveEmptyArgGates
+
+
+def _invokes(mt):
+    return [stmt.callee.sym_name for stmt in mt.code.walk() if isinstance(stmt, Invoke)]
+
+
+def test_removes_empty_broadcast_gate():
+    @squin.kernel
+    def main():
+        q = squin.qalloc(2)
+        squin.broadcast.h(q)
+        squin.broadcast.x([])
+
+    RemoveEmptyArgGates(main.dialects)(main)
+
+    invokes = _invokes(main)
+    assert "x" not in invokes
+    assert "h" in invokes
+
+
+def test_removes_empty_noise_and_controlled():
+    @squin.kernel
+    def main():
+        q = squin.qalloc(2)
+        squin.broadcast.depolarize(0.1, [])
+        squin.broadcast.cx([], [])
+        squin.broadcast.h(q)
+
+    RemoveEmptyArgGates(main.dialects)(main)
+
+    invokes = _invokes(main)
+    assert "depolarize" not in invokes
+    assert "cx" not in invokes
+    assert "h" in invokes
+
+
+def test_removes_unused_empty_measurement():
+    @squin.kernel
+    def main():
+        squin.measure([])
+
+    RemoveEmptyArgGates(main.dialects)(main)
+
+    assert "measure" not in _invokes(main)
+
+
+def test_keeps_non_empty_gates():
+    @squin.kernel
+    def main():
+        q = squin.qalloc(2)
+        squin.broadcast.h(q)
+        squin.broadcast.cx([q[0]], [q[1]])
+
+    RemoveEmptyArgGates(main.dialects)(main)
+
+    invokes = _invokes(main)
+    assert "h" in invokes
+    assert "cx" in invokes
+
+
+def test_keeps_used_measurement():
+    @squin.kernel
+    def main():
+        q = squin.qalloc(1)
+        return squin.measure(q)
+
+    RemoveEmptyArgGates(main.dialects)(main)
+
+    assert "measure" in _invokes(main)
+
+
+def test_dce_removes_emptied_function_call():
+    @squin.kernel
+    def sub():
+        squin.broadcast.x([])
+
+    @squin.kernel
+    def main():
+        q = squin.qalloc(1)
+        squin.broadcast.h(q)
+        sub()
+
+    RemoveEmptyArgGates(main.dialects)(main)
+
+    invokes = _invokes(main)
+    assert "sub" not in invokes
+    assert "h" in invokes


### PR DESCRIPTION
Closes #516

## Summary

Adds `RemoveEmptyArgGates`, a `CallGraphPass` that removes squin gates, noise channels and measurements applied to compile-time empty qubit lists (a no-op), and cleans up anything left dead with DCE.

```python
from bloqade import squin
from bloqade.rewrite.passes import RemoveEmptyArgGates

@squin.kernel
def main():
    q = squin.qalloc(2)
    squin.broadcast.h(q)
    squin.broadcast.x([])   # removed

RemoveEmptyArgGates(main.dialects)(main)
```

## How it works

The length-0 information lives at the call site, not inside the wrapper functions: a `broadcast.x([])` is a `func.Invoke` whose argument type is `IList[…, Literal(0)]`, while inside `broadcast.x` the gate's `qubits` argument is just `IList[Qubit, Any]`. So the pass applies two rules across the call graph:

- **`RemoveEmptyGate`** — removes a gate / noise / measurement **statement** whose qubit-list argument(s) (`qubits`, or `controls`/`targets`) have compile-time length 0. Skipped if the statement has used results (keeps measurements safe).
- **`RemoveEmptyGateCall`** — removes a `func.Invoke` to a *qubit-op wrapper* when its qubit-list argument(s) are length 0 and its result is unused. A wrapper qualifies if its only effects are qubit ops applied to its arguments (everything else is `kirin.ir.traits.Pure`), so invoking it on empty lists does nothing. This is what removes the stdlib `broadcast.*([])` calls.

`RemoveEmptyArgGates` runs `CallGraphPass(rule=Walk(Chain(RemoveEmptyGate, RemoveEmptyGateCall)))` followed by `Fixpoint(Walk(DeadCodeElimination))`. DCE removes dead constants and any function emptied by the rewrite — this is the issue's "combine with DCE / add another rule" requirement (`RemoveEmptyGateCall` is that additional rule, needed because the inner gate keeps `Any` length so the wrapper body itself is never emptied).

## Changes

| File | Change |
|------|--------|
| `src/bloqade/rewrite/rules/remove_empty_gates.py` | New — `RemoveEmptyGate`, `RemoveEmptyGateCall`, and the length / wrapper helpers |
| `src/bloqade/rewrite/passes/remove_empty_arg_gates.py` | New — `RemoveEmptyArgGates` pass (CallGraphPass + DCE) |
| `src/bloqade/rewrite/rules/__init__.py` | Export the two rules |
| `src/bloqade/rewrite/passes/__init__.py` | Export `RemoveEmptyArgGates` |
| `test/squin/passes/test_remove_empty_arg_gates.py` | New — 6 tests |

## Tests

`test/squin/passes/test_remove_empty_arg_gates.py`: the issue example (`broadcast.x([])` removed, `broadcast.h(q)` kept); empty noise channel and controlled gate removed; unused empty measurement removed; non-empty gates and a *used* measurement kept; and a nested function emptied by the rewrite is removed via the CallGraph + DCE path. All pass, with no regressions across the repo suite.

---

### AI disclosure

I used Claude as an assistant while working on this , mostly for scaffolding and tests and as a sounding board. The approach came from reading the IR directly (confirming the empty length surfaces at the `Invoke` call site, not inside the wrapper, which is why the pass works on invokes and uses the `Pure` trait to keep removal safe). I reviewed and tested everything against the codebase.