### PR TITLE
rewrite: add RemoveEmptyArgGates pass (closes #516)

### DIFF
--- a/src/bloqade/rewrite/passes/__init__.py
+++ b/src/bloqade/rewrite/passes/__init__.py
@@ -5,3 +5,5 @@ from .callgraph import (
 )
 from .aggressive_unroll import AggressiveUnroll as AggressiveUnroll
 from .canonicalize_ilist import CanonicalizeIList as CanonicalizeIList
+from .remove_empty_args import RemoveEmptyArgGates as RemoveEmptyArgGates
+from .remove_empty_args import RemoveEmptyArgGates as RemoveEmptyArgGates

--- a/src/bloqade/rewrite/passes/remove_empty_args.py
+++ b/src/bloqade/rewrite/passes/remove_empty_args.py
@@ -1,0 +1,62 @@
+from dataclasses import dataclass, field
+
+from kirin import ir, passes
+from kirin.dialects.ilist.runtime import IList
+from kirin.dialects.func.stmts import Invoke
+from kirin.ir.attrs.types import Generic, Literal, PyClass
+from kirin.rewrite import Walk, Chain, DeadCodeElimination
+from kirin.rewrite.abc import RewriteRule, RewriteResult
+
+from .callgraph import CallGraphPass
+
+_ILIST_BODY = PyClass(IList)
+
+
+def _has_empty_ilist_input(node: Invoke) -> bool:
+    for inp in node.inputs:
+        t = inp.type
+        if not isinstance(t, Generic):
+            continue
+        if t.body != _ILIST_BODY:
+            continue
+        if len(t.vars) < 2:
+            continue
+        len_var = t.vars[1]
+        if isinstance(len_var, Literal) and len_var.data == 0:
+            return True
+    return False
+
+
+class RemoveEmptyArgGatesRule(RewriteRule):
+    """Delete Invoke statements whose qubit-list argument is a compile-time empty IList."""
+
+    def rewrite_Statement(self, node: ir.Statement) -> RewriteResult:
+        if not isinstance(node, Invoke):
+            return RewriteResult()
+        if not _has_empty_ilist_input(node):
+            return RewriteResult()
+        node.delete(safe=False)
+        return RewriteResult(has_done_something=True)
+
+
+@dataclass
+class RemoveEmptyArgGates(passes.Pass):
+    """Remove squin gate/noise/measurement calls on empty qubit lists.
+
+    Usage::
+
+        RemoveEmptyArgGates(main.dialects)(main)
+    """
+
+    _inner: CallGraphPass = field(init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        rule = Walk(Chain(RemoveEmptyArgGatesRule(), DeadCodeElimination()))
+        self._inner = CallGraphPass(
+            rule=rule,
+            dialects=self.dialects,
+            no_raise=self.no_raise,
+        )
+
+    def unsafe_run(self, mt: ir.Method) -> RewriteResult:
+        return self._inner.unsafe_run(mt)

--- a/test/rewrite/test_remove_empty_args.py
+++ b/test/rewrite/test_remove_empty_args.py
@@ -1,0 +1,109 @@
+import bloqade.squin as squin
+from bloqade.rewrite.passes.remove_empty_args import (
+    RemoveEmptyArgGates,
+    _has_empty_ilist_input,
+)
+from kirin.dialects.func.stmts import Invoke
+
+
+def _invoke_names(mt):
+    return [s.callee.sym_name for s in mt.code.walk() if isinstance(s, Invoke)]
+
+
+def test_empty_broadcast_detected():
+    @squin.kernel
+    def k():
+        squin.broadcast.x([])
+    invokes = [s for s in k.code.walk() if isinstance(s, Invoke) and s.callee.sym_name == "x"]
+    assert invokes
+    assert _has_empty_ilist_input(invokes[0])
+
+
+def test_nonempty_broadcast_not_detected():
+    @squin.kernel
+    def k():
+        q = squin.qalloc(2)
+        squin.broadcast.h(q)
+    invokes = [s for s in k.code.walk() if isinstance(s, Invoke) and s.callee.sym_name == "h"]
+    assert invokes
+    assert not _has_empty_ilist_input(invokes[0])
+
+
+def test_removes_empty_broadcast():
+    @squin.kernel
+    def main():
+        q = squin.qalloc(2)
+        squin.broadcast.h(q)
+        squin.broadcast.x([])
+
+    result = RemoveEmptyArgGates(main.dialects)(main)
+    assert result.has_done_something
+    names = _invoke_names(main)
+    assert "x" not in names
+    assert "h" in names
+
+
+def test_removes_multiple_empty_broadcasts():
+    @squin.kernel
+    def main():
+        q = squin.qalloc(1)
+        squin.broadcast.h(q)
+        squin.broadcast.x([])
+        squin.broadcast.y([])
+        squin.broadcast.z([])
+
+    result = RemoveEmptyArgGates(main.dialects)(main)
+    assert result.has_done_something
+    names = _invoke_names(main)
+    for gate in ("x", "y", "z"):
+        assert gate not in names
+    assert "h" in names
+
+
+def test_preserves_nonempty():
+    @squin.kernel
+    def main():
+        q = squin.qalloc(2)
+        squin.broadcast.h(q)
+
+    result = RemoveEmptyArgGates(main.dialects)(main)
+    assert not result.has_done_something
+
+
+def test_idempotent():
+    @squin.kernel
+    def main():
+        q = squin.qalloc(2)
+        squin.broadcast.x([])
+
+    RemoveEmptyArgGates(main.dialects)(main)
+    result2 = RemoveEmptyArgGates(main.dialects)(main)
+    assert not result2.has_done_something
+
+
+def test_dce_cleans_dead_constant():
+    @squin.kernel
+    def main():
+        q = squin.qalloc(2)
+        squin.broadcast.x([])
+
+    RemoveEmptyArgGates(main.dialects)(main)
+
+    from kirin.dialects.py import Constant as PyConstant
+    from kirin.dialects.ilist.runtime import IList
+    dead = [s for s in main.code.walk()
+            if isinstance(s, PyConstant) and isinstance(s.value, IList) and len(s.value) == 0]
+    assert not dead
+
+
+def test_issue_516_example():
+    @squin.kernel
+    def main():
+        q = squin.qalloc(2)
+        squin.broadcast.h(q)
+        squin.broadcast.x([])
+
+    RemoveEmptyArgGates(main.dialects)(main)
+    names = _invoke_names(main)
+    assert "x" not in names
+    assert "h" in names


### PR DESCRIPTION
Closes #516
 **What this does:**
Implements `RemoveEmptyArgGates`, a `CallGraphPass` that walks the IR
and removes any `func.invoke` node whose qubit-list argument is a
compile-time-empty `IList` (i.e. `Literal(0)` length). Such calls are
no-ops. DCE cleans up the dead `IList([])` constant afterward.

** Files changed**
- `src/bloqade/rewrite/passes/remove_empty_args.py` - new pass
- `src/bloqade/rewrite/passes/__init__.py` - export `RemoveEmptyArgGates`
- `tests/test_remove_empty_args.py` - 8 tests

**Usage**
```python
from bloqade.rewrite.passes import RemoveEmptyArgGates
RemoveEmptyArgGates(main.dialects)(main)
```
**AI usage**
Used Claude (Anthropic) for debugging guidance.