### PR TITLE
Add SQUIN Clifford validation

### DIFF
--- a/src/bloqade/squin/analysis/validation/__init__.py
+++ b/src/bloqade/squin/analysis/validation/__init__.py
@@ -1,0 +1,1 @@
+from .clifford import CliffordValidation as CliffordValidation

--- a/src/bloqade/squin/analysis/validation/clifford.py
+++ b/src/bloqade/squin/analysis/validation/clifford.py
@@ -1,0 +1,61 @@
+from typing import Any
+
+from kirin import ir
+from kirin.analysis import CallGraph
+from kirin.validation import ValidationPass
+
+from bloqade.squin import gate
+
+
+_CLIFFORD_GATE_TYPES = (
+    gate.stmts.X,
+    gate.stmts.Y,
+    gate.stmts.Z,
+    gate.stmts.H,
+    gate.stmts.S,
+    gate.stmts.SqrtX,
+    gate.stmts.SqrtY,
+    gate.stmts.CX,
+    gate.stmts.CY,
+    gate.stmts.CZ,
+)
+
+
+def _gate_name(stmt: gate.stmts.Gate) -> str:
+    return type(stmt).__name__
+
+
+class CliffordValidation(ValidationPass):
+    """Validate that a SQUIN kernel only contains Clifford gates.
+
+    This pass walks the method's call graph so kernels using the public SQUIN
+    wrappers, such as ``squin.t(q[0])``, are checked without requiring callers
+    to manually inline the kernel first.
+    """
+
+    def name(self) -> str:
+        return "Clifford Validation"
+
+    def run(self, method: ir.Method) -> tuple[Any, list[ir.ValidationError]]:
+        errors: list[ir.ValidationError] = []
+
+        call_graph = CallGraph(method)
+        methods = set(call_graph.edges.keys())
+        methods.add(method)
+
+        for current_method in methods:
+            for stmt in current_method.callable_region.walk():
+                if not isinstance(stmt, gate.stmts.Gate):
+                    continue
+
+                if isinstance(stmt, _CLIFFORD_GATE_TYPES):
+                    continue
+
+                errors.append(
+                    ir.ValidationError(
+                        stmt,
+                        f"Gate {_gate_name(stmt)} is not allowed in a Clifford-only SQUIN kernel.",
+                    )
+                )
+
+        return method, errors

--- a/test/squin/validation/test_clifford.py
+++ b/test/squin/validation/test_clifford.py
@@ -1,0 +1,58 @@
+import pytest
+from kirin.validation import ValidationSuite
+from kirin.ir.exception import ValidationErrorGroup
+
+from bloqade import squin
+from bloqade.squin.analysis.validation import CliffordValidation
+
+
+def test_clifford_kernel_is_valid():
+    @squin.kernel
+    def main_clifford():
+        q = squin.qalloc(4)
+        squin.h(q[0])
+        for i in range(3):
+            squin.cx(q[i], q[i + 1])
+
+    _, errors = CliffordValidation().run(main_clifford)
+    assert len(errors) == 0
+
+
+def test_non_clifford_kernel_is_invalid():
+    @squin.kernel
+    def main_nonclifford():
+        q = squin.qalloc(4)
+        squin.h(q[0])
+        for i in range(3):
+            squin.t(q[i])
+            squin.cx(q[i], q[i + 1])
+
+    _, errors = CliffordValidation().run(main_nonclifford)
+    assert len(errors) > 0
+    assert "T" in str(errors[0])
+
+
+def test_validation_suite_raises_for_non_clifford_gate():
+    @squin.kernel
+    def main_nonclifford():
+        q = squin.qalloc(1)
+        squin.rx(0.25, q[0])
+
+    suite = ValidationSuite([CliffordValidation])
+    result = suite.validate(main_nonclifford)
+    assert result.error_count() == 1
+
+    with pytest.raises(ValidationErrorGroup):
+        result.raise_if_invalid()
+
+
+def test_clifford_adjoint_gates_are_valid():
+    @squin.kernel
+    def main_clifford():
+        q = squin.qalloc(3)
+        squin.s_adj(q[0])
+        squin.sqrt_x_adj(q[1])
+        squin.sqrt_y_adj(q[2])
+
+    _, errors = CliffordValidation().run(main_clifford)
+    assert len(errors) == 0


### PR DESCRIPTION
Closes #665.

## Summary
- Add `CliffordValidation` under `bloqade.squin.analysis.validation`.
- Walk the kernel call graph so public SQUIN wrappers such as `squin.t(q[0])` are checked without requiring manual inlining first.
- Reject SQUIN gate statements outside the named Clifford gate set while allowing Clifford adjoint wrappers such as `s_adj`, `sqrt_x_adj`, and `sqrt_y_adj`.

## Notes
This is an explicit validation pass rather than an unconditional change to `SquinToStimPass`, so existing non-Clifford Stim annotation support remains unchanged for callers that still need it.

## Validation
- `python -m pytest test\squin\validation\test_clifford.py`
- `python -m pytest test\squin\validation\test_simple_nocloning.py`
- `python -m pytest test\stim\from_squin_validation\test_from_squin_validation.py`
- `python -m pytest test\stim\passes\test_squin_non_clifford_to_stim.py`
- `python -m py_compile src\bloqade\squin\analysis\validation\clifford.py test\squin\validation\test_clifford.py`
- `ruff check src\bloqade\squin\analysis\validation\clifford.py src\bloqade\squin\analysis\validation\__init__.py test\squin\validation\test_clifford.py`
- `git diff --check`