### PR TITLE
feat(squin): Clifford layer optimizer (fixed-CZ frame search)

### DIFF
--- a/src/bloqade/squin/layer_optimizer/__init__.py
+++ b/src/bloqade/squin/layer_optimizer/__init__.py
@@ -1,0 +1,6 @@
+"""Layer-optimization helpers for Clifford circuits.
+
+Pure cirq leaves used by ``LayerOptimize``: ``schedule`` (per-CZ-gap extraction
+and frame materialization), ``simplify`` (combine diagonals through CZ), ``cost``
+(fast layer-count predictor), and ``search`` (bounded-uphill frame search).
+"""

--- a/src/bloqade/squin/layer_optimizer/cost.py
+++ b/src/bloqade/squin/layer_optimizer/cost.py
@@ -1,0 +1,111 @@
+"""Fast 1q pulse-layer count for a normalized cirq circuit.
+
+`predicted_layer_count` reuses ParallelizeLayer's scheduler (`pierce_into_fixed`)
+on a cheap graph built directly from a cirq circuit — no IR — so the frame search
+can score candidates cheaply. The count is the number of distinct (level,
+gate-type) groups among non-Pauli 1q gates, matching what ParallelizeLayer
+materializes.
+"""
+
+from collections import deque
+
+import cirq
+
+from bloqade.squin.rewrite.parallelize import pierce_into_fixed
+
+_CZ = cirq.CZ
+_DIAG = frozenset({cirq.S, cirq.S**-1, cirq.Z})
+_PAULI = frozenset({cirq.X, cirq.Y, cirq.Z})
+
+
+def predicted_layer_count(circuit: cirq.Circuit) -> int:
+    """Predicted number of 1q pulse layers ParallelizeLayer would produce."""
+    ops = list(circuit.all_operations())
+    ids = list(range(len(ops)))
+    gate = [op.gate for op in ops]
+    is_cz = [g == _CZ for g in gate]
+    is_diag = [g in _DIAG for g in gate]
+
+    by_qubit: dict = {}
+    for i in ids:
+        for q in ops[i].qubits:
+            by_qubit.setdefault(q, []).append(i)
+
+    raw_out = {i: set() for i in ids}
+    for chain in by_qubit.values():
+        for a, b in zip(chain, chain[1:]):
+            raw_out[a].add(b)
+
+    inc = {i: set() for i in ids}
+    out = {i: set() for i in ids}
+
+    def link(a, b):
+        out[a].add(b)
+        inc[b].add(a)
+
+    # Commutation edges: diagonals bounded by neighbouring non-diagonal gates,
+    # never by CZ (mirrors ParallelizeLayer._commutation_edges).
+    for chain in by_qubit.values():
+        prev_backbone = prev_wall = prev_diag = None
+        open_diags: list = []
+        for k in chain:
+            if is_diag[k]:
+                if prev_wall is not None:
+                    link(prev_wall, k)
+                if prev_diag is not None:
+                    link(prev_diag, k)
+                prev_diag = k
+                open_diags.append(k)
+            else:
+                if prev_backbone is not None:
+                    link(prev_backbone, k)
+                prev_backbone = k
+                if not is_cz[k]:
+                    for d in open_diags:
+                        link(d, k)
+                    open_diags = []
+                    prev_wall = k
+
+    cz_ids = [i for i in ids if is_cz[i]]
+
+    def cz_succ(start):
+        res, stack, seen = set(), list(raw_out[start]), set()
+        while stack:
+            m = stack.pop()
+            if m in seen:
+                continue
+            seen.add(m)
+            if is_cz[m]:
+                res.add(m)
+            else:
+                stack.extend(raw_out[m])
+        return res
+
+    succ = {k: cz_succ(k) for k in cz_ids}
+    cinc = {k: set() for k in cz_ids}
+    for k in cz_ids:
+        for m in succ[k]:
+            cinc[m].add(k)
+    indeg = {k: len(cinc[k]) for k in cz_ids}
+    dq = deque(k for k in cz_ids if indeg[k] == 0)
+    depth = {k: 0 for k in cz_ids}
+    while dq:
+        k = dq.popleft()
+        for m in succ[k]:
+            depth[m] = max(depth[m], depth[k] + 1)
+            indeg[m] -= 1
+            if indeg[m] == 0:
+                dq.append(m)
+
+    big = len(ids) + 1
+    fixed = {k: (depth[k] + 1) * big for k in cz_ids}
+    top = (max(depth.values(), default=-1) + 2) * big
+    key_of = {i: gate[i] for i in ids}
+    levels = pierce_into_fixed(ids, inc, out, key_of, fixed, top)
+
+    groups = set()
+    for i in ids:
+        if is_cz[i] or gate[i] in _PAULI:
+            continue
+        groups.add((levels[i], gate[i]))
+    return len(groups)

--- a/src/bloqade/squin/layer_optimizer/schedule.py
+++ b/src/bloqade/squin/layer_optimizer/schedule.py
@@ -1,0 +1,154 @@
+"""Cirq op-space layer scheduling.
+
+Two halves of the layer optimizer that touch the circuit representation:
+
+  - extract_layers: read the per-CZ-gap structure (intrinsic axis per qubit,
+    S-residue qubits) that the cirq-free greedy search consumes.
+  - apply_schedule: materialize the greedy's chosen frame schedule by
+    S-conjugation.
+
+Both operate on a cirq.Circuit already in CliffordNormalize form
+(body = {SqrtX, SqrtY, S, CZ}, Paulis trailing).
+
+Materialization inserts ONE S where a qubit's frame turns on (0->1) and one
+S† where it turns off (1->0), conjugating every gate inside an active frame:
+
+    SqrtX <-> SqrtY,   X <-> Y,   S and Z unchanged.
+
+Because S commutes through CZ, a frame persists across walls untouched, and
+the inserted S / S† telescope — so the result equals the input up to the
+trailing Pauli layer, with no per-qubit bookkeeping. Daggers and Paulis that
+conjugation introduces are cleaned up by re-running the Pauli ejector.
+"""
+
+import cirq
+
+
+def _gate_label(op: cirq.Operation) -> str | None:
+    g = op.gate
+    if g == cirq.X:
+        return "X"
+    if g == cirq.Y:
+        return "Y"
+    if g == cirq.Z:
+        return "Z"
+    if g == cirq.S:
+        return "S"
+    if g == cirq.S**-1:
+        return "SDag"
+    if g == cirq.X**0.5:
+        return "SqrtX"
+    if g == cirq.X**-0.5:
+        return "SqrtXDag"
+    if g == cirq.Y**0.5:
+        return "SqrtY"
+    if g == cirq.Y**-0.5:
+        return "SqrtYDag"
+    return None
+
+
+_AXIS = {"SqrtX": "X", "SqrtY": "Y"}
+
+
+def extract_layers(
+    circuit: cirq.Circuit,
+) -> tuple[list[dict], list[set], list[cirq.Qid]]:
+    """Return (layer_data, s_qubits, qubits) partitioned by CZ wall.
+
+    All lists are indexed by gap (gap 0 before the first CZ). `layer_data[i]`
+    maps qubit -> intrinsic axis ('X' or 'Y'); `s_qubits[i]` is the set of
+    qubits with an S residue in gap i; `qubits` is every qubit, first-seen.
+    """
+    layer_data: list[dict] = [{}]
+    s_qubits: list[set] = [set()]
+    qubits: list[cirq.Qid] = []
+    seen: set = set()
+
+    def _rec(q):
+        if q not in seen:
+            seen.add(q)
+            qubits.append(q)
+
+    for op in circuit.all_operations():
+        if op.gate == cirq.CZ:
+            for q in op.qubits:
+                _rec(q)
+            layer_data.append({})
+            s_qubits.append(set())
+            continue
+        q = op.qubits[0]
+        _rec(q)
+        label = _gate_label(op)
+        if label in _AXIS:
+            layer_data[-1][q] = _AXIS[label]
+        elif label in ("S", "SDag"):
+            s_qubits[-1].add(q)
+    return layer_data, s_qubits, qubits
+
+
+# Conjugation of a body gate by S^1 (S g S†), keyed by _gate_label.
+_CONJ = {
+    "SqrtX": lambda q: (cirq.Y**0.5)(q),
+    "SqrtY": lambda q: (cirq.X**-0.5)(q),
+    "S": lambda q: cirq.S(q),
+    "SDag": lambda q: (cirq.S**-1)(q),
+    "X": lambda q: cirq.Y(q),
+    "Y": lambda q: cirq.X(q),
+    "Z": lambda q: cirq.Z(q),
+}
+
+
+def apply_schedule(circuit: cirq.Circuit, schedule: list[dict]) -> cirq.Circuit:
+    """Rewrite `circuit` to realize `schedule` (length num_gaps + 1).
+
+    `schedule[i]` is the per-qubit frame (0/1) in effect during gap i-1 ->
+    gap i; schedule[0] is the all-zero initial frame. Returns a new circuit;
+    the caller should re-run the Pauli ejector to collapse the daggers and
+    Paulis this introduces.
+    """
+    gaps: list[list[cirq.Operation]] = [[]]
+    walls: list[cirq.Operation] = []
+    for op in circuit.all_operations():
+        if op.gate == cirq.CZ:
+            walls.append(op)
+            gaps.append([])
+        else:
+            gaps[-1].append(op)
+
+    if len(schedule) != len(gaps) + 1:
+        raise ValueError(
+            f"schedule length {len(schedule)} != num_gaps+1 {len(gaps) + 1}"
+        )
+
+    new_ops: list[cirq.Operation] = []
+    frame: dict = {}
+    for i, gap in enumerate(gaps):
+        for q, target in schedule[i + 1].items():
+            cur = frame.get(q, 0)
+            if target > cur:
+                new_ops.append(cirq.S(q))
+            elif target < cur:
+                new_ops.append((cirq.S**-1)(q))
+            frame[q] = target
+        for op in gap:
+            q = op.qubits[0]
+            if frame.get(q, 0) % 2:
+                conj = _CONJ.get(_gate_label(op))
+                if conj is None:
+                    raise ValueError(
+                        f"cannot conjugate non-normalized gate {op.gate!r}; "
+                        "expected CliffordNormalize form {SqrtX, SqrtY, S, "
+                        "X, Y, Z, CZ}"
+                    )
+                new_ops.append(conj(q))
+            else:
+                new_ops.append(op)
+        if i < len(walls):
+            new_ops.append(walls[i])
+
+    # Close any still-active frame so the lab frame returns to identity.
+    for q, f in frame.items():
+        if f % 2:
+            new_ops.append((cirq.S**-1)(q))
+
+    return cirq.Circuit(new_ops)

--- a/src/bloqade/squin/layer_optimizer/search.py
+++ b/src/bloqade/squin/layer_optimizer/search.py
@@ -1,0 +1,70 @@
+"""Bounded-uphill frame search for LayerOptimize.
+
+Plateau moves are inert for this problem (every single frame flip is strictly
+uphill), so acceptance allows a bounded uphill step (tau=1) and keeps the best
+frame seen. Deterministic (fixed move order + tabu, no RNG). The objective is
+the fast `predicted_layer_count` of the materialized frame.
+
+The `eject` callable (a cirq.Circuit -> cirq.Circuit Pauli ejector) is passed in
+by the caller so this module stays a leaf — it must run before counting, because
+conjugation in apply_schedule produces daggered gates (e.g. √Y -> √X†) that
+eject collapses to the positive gate + a free Pauli; counting them undaggered
+would inflate the distinct-type tally.
+"""
+
+from bloqade.squin.layer_optimizer.cost import predicted_layer_count
+from bloqade.squin.layer_optimizer.schedule import apply_schedule
+from bloqade.squin.layer_optimizer.simplify import simplify_diagonals
+
+
+def _key(frame: dict, qubits) -> tuple:
+    return tuple(tuple(frame[q]) for q in qubits)
+
+
+def _schedule(frame: dict, qubits, n_gaps: int) -> list:
+    return [{q: 0 for q in qubits}] + [
+        {q: frame[q][i] for q in qubits} for i in range(n_gaps)
+    ]
+
+
+def optimize_threshold_accept(
+    c_norm, layer_data, qubits, eject, *, tau: int = 1, max_iters: int = 200
+) -> list:
+    """Deterministic bounded-uphill search; returns the best frame schedule.
+
+    `eject` is a cirq.Circuit -> cirq.Circuit Pauli ejector applied before each
+    cost evaluation.
+    """
+    n_gaps = len(layer_data)
+    moves = [(q, i) for i in range(n_gaps) for q in layer_data[i]]
+    frame = {q: [0] * n_gaps for q in qubits}
+
+    def cost(sched):
+        return predicted_layer_count(
+            simplify_diagonals(eject(apply_schedule(c_norm, sched)))
+        )
+
+    cur = cost(_schedule(frame, qubits, n_gaps))
+    best, best_frame = cur, {q: frame[q][:] for q in qubits}
+    seen = {_key(frame, qubits)}
+    for _ in range(max_iters):
+        chosen = chosen_cost = chosen_key = None
+        for q, i in moves:
+            frame[q][i] ^= 1
+            k = _key(frame, qubits)
+            c = cost(_schedule(frame, qubits, n_gaps)) if k not in seen else None
+            frame[q][i] ^= 1
+            if (
+                c is not None
+                and c - cur <= tau
+                and (chosen_cost is None or c < chosen_cost)
+            ):
+                chosen, chosen_cost, chosen_key = (q, i), c, k
+        if chosen is None:
+            break
+        frame[chosen[0]][chosen[1]] ^= 1
+        seen.add(chosen_key)
+        cur = chosen_cost
+        if cur < best:
+            best, best_frame = cur, {q: frame[q][:] for q in qubits}
+    return _schedule(best_frame, qubits, n_gaps)

--- a/src/bloqade/squin/layer_optimizer/simplify.py
+++ b/src/bloqade/squin/layer_optimizer/simplify.py
@@ -1,0 +1,43 @@
+"""Combine per-qubit diagonal (S/S†/Z) runs through CZ into a single gate.
+
+Diagonal gates commute through CZ and are blocked only by that qubit's own axis
+gates (√X/√Y/X/Y). Within each segment between consecutive axis gates, all
+diagonal quarter-turns combine to a net power of S (mod 4): net 0 -> identity
+(dropped), net 2 -> Z (free Pauli), net 1 -> S, net 3 -> S†.
+"""
+
+import cirq
+
+
+def simplify_diagonals(circuit: cirq.Circuit) -> cirq.Circuit:
+    """Return an equivalent circuit with per-qubit diagonal runs combined."""
+    pending: dict[cirq.Qid, int] = {}
+    out: list[cirq.Operation] = []
+    s_dag = cirq.S**-1
+
+    def flush(q: cirq.Qid) -> None:
+        n = pending.get(q, 0) % 4
+        if n == 1:
+            out.append(cirq.S(q))
+        elif n == 2:
+            out.append(cirq.Z(q))
+        elif n == 3:
+            out.append(s_dag(q))
+        pending[q] = 0
+
+    for op in circuit.all_operations():
+        g = op.gate
+        if g == cirq.CZ:
+            out.append(op)
+        elif g == cirq.S:
+            pending[op.qubits[0]] = pending.get(op.qubits[0], 0) + 1
+        elif g == s_dag:
+            pending[op.qubits[0]] = pending.get(op.qubits[0], 0) + 3
+        elif g == cirq.Z:
+            pending[op.qubits[0]] = pending.get(op.qubits[0], 0) + 2
+        else:
+            flush(op.qubits[0])
+            out.append(op)
+    for q in list(pending):
+        flush(q)
+    return cirq.Circuit(out)

--- a/src/bloqade/squin/passes/__init__.py
+++ b/src/bloqade/squin/passes/__init__.py
@@ -1,2 +1,7 @@
+"""Compiler passes for the squin dialect."""
+
+from .parallelize import ParallelizeLayer as ParallelizeLayer
+from .layer_optimize import LayerOptimize as LayerOptimize
 from .qasm2_to_squin import QASM2ToSquin as QASM2ToSquin
 from .qasm3_to_squin import QASM3ToSquin as QASM3ToSquin
+from .clifford_normalize import CliffordNormalize as CliffordNormalize

--- a/src/bloqade/squin/passes/_schedule_impls.py
+++ b/src/bloqade/squin/passes/_schedule_impls.py
@@ -1,0 +1,75 @@
+"""DagScheduleAnalysis method-table implementations for the squin.gate dialect.
+
+Lives under `squin.passes` (rather than `squin.gate`) so registration happens
+after `bloqade.qasm2` has fully loaded — avoids a circular import with
+`bloqade.squin.analysis.schedule`, which depends on `bloqade.qasm2.parse.print`.
+
+Mirrors `bloqade.qasm2.dialects.uop.schedule.UOpSchedule`. Each gate stmt
+carries its qubits as one ilist SSA value; `update_dag` follows the address
+analysis (which returns `AddressReg` for the ilist) to identify the qubits
+the stmt touches.
+"""
+
+from kirin import interp
+from kirin.analysis import ForwardFrame
+
+import bloqade.qasm2 as _qasm2  # noqa: F401  load qasm2 before analysis.schedule
+from bloqade.squin.gate import stmts
+from bloqade.squin.gate._dialect import dialect
+from bloqade.squin.analysis.schedule import DagScheduleAnalysis
+
+
+@dialect.register(key="qasm2.schedule.dag")
+class SquinGateSchedule(interp.MethodTable):
+
+    @interp.impl(stmts.X)
+    @interp.impl(stmts.Y)
+    @interp.impl(stmts.Z)
+    @interp.impl(stmts.H)
+    @interp.impl(stmts.T)
+    @interp.impl(stmts.S)
+    @interp.impl(stmts.SqrtX)
+    @interp.impl(stmts.SqrtY)
+    def single_qubit_gate(
+        self,
+        interp: DagScheduleAnalysis,
+        frame: ForwardFrame,
+        stmt: stmts.SingleQubitGate,
+    ):
+        interp.update_dag(stmt, [stmt.qubits])
+        return ()
+
+    @interp.impl(stmts.Rx)
+    @interp.impl(stmts.Ry)
+    @interp.impl(stmts.Rz)
+    def rotation_gate(
+        self,
+        interp: DagScheduleAnalysis,
+        frame: ForwardFrame,
+        stmt: stmts.RotationGate,
+    ):
+        interp.update_dag(stmt, [stmt.qubits])
+        return ()
+
+    @interp.impl(stmts.U3)
+    @interp.impl(stmts.PhasedXZ)
+    def parameterized_single_qubit_gate(
+        self,
+        interp: DagScheduleAnalysis,
+        frame: ForwardFrame,
+        stmt: stmts.Gate,
+    ):
+        interp.update_dag(stmt, [stmt.qubits])
+        return ()
+
+    @interp.impl(stmts.CX)
+    @interp.impl(stmts.CY)
+    @interp.impl(stmts.CZ)
+    def controlled_gate(
+        self,
+        interp: DagScheduleAnalysis,
+        frame: ForwardFrame,
+        stmt: stmts.ControlledGate,
+    ):
+        interp.update_dag(stmt, [stmt.controls, stmt.targets])
+        return ()

--- a/src/bloqade/squin/passes/clifford_normalize.py
+++ b/src/bloqade/squin/passes/clifford_normalize.py
@@ -1,0 +1,290 @@
+"""CliffordNormalize: convert a Clifford circuit to a canonical form.
+
+Pipeline (cirq-side, round-tripped back to squin):
+
+  1. emit_circuit: squin IR -> cirq.Circuit.
+  2. eject Paulis & Z gates to the end (Pauli-frame extraction).
+  3. merge consecutive 1q gates into PhasedXZ.
+  4. decompose each PhasedXZ into a sequence of quarter-turns around X and Z
+     (`{SqrtX, S}` and their inverses, plus Paulis as length-1 matches).
+  5. load_circuit: cirq.Circuit -> squin IR; overwrite `mt.code`.
+  6. Canonicalize Rx(±π/2) -> SqrtX (via SquinU3ToClifford).
+
+After step 6 the body contains only `{SqrtX±, S±, CZ}`; all `X/Y/Z` Paulis
+live in a trailing layer at the very end of the circuit (or are absorbed by
+cirq's eject transformers).
+
+This pass does NOT optimize layer counts — it produces a canonical form
+that the kirin-native `LayerOptimize` pass then operates on.
+"""
+
+from dataclasses import dataclass
+
+import cirq
+from kirin import ir
+from kirin.passes import Pass
+from kirin.rewrite import (
+    Walk,
+    Chain,
+    Fixpoint,
+    ConstantFold,
+    CommonSubexpressionElimination,
+    abc,
+)
+
+from bloqade.cirq_utils import emit_circuit, load_circuit
+from bloqade.squin.rewrite import SquinU3ToClifford
+from bloqade.squin.layer_optimizer.schedule import _gate_label
+
+
+# Final gate set: half-turn axis pulses around X and Y, S±, Paulis.
+# Including SqrtY± keeps Y-axis rotations as single primitives rather than
+# expanding them into a 3-primitive (S · SqrtX · S†) sequence.
+def _primitive_ops(q: cirq.Qid) -> list[cirq.Operation]:
+    return [
+        (cirq.X**0.5)(q),
+        (cirq.X**-0.5)(q),
+        (cirq.Y**0.5)(q),
+        (cirq.Y**-0.5)(q),
+        cirq.S(q),
+        (cirq.S**-1)(q),
+        cirq.X(q),
+        cirq.Y(q),
+        cirq.Z(q),
+    ]
+
+
+_DECOMP_CACHE: dict[tuple, tuple[cirq.Operation, ...] | None] = {}
+
+
+def _matrix_key(u) -> tuple:
+    """Hashable key for a 2x2 unitary normalized to a canonical global phase."""
+    flat = u.reshape(-1)
+    pivot = next((x for x in flat if abs(x) > 1e-9), 1.0)
+    norm = flat / pivot
+    return tuple(round(x.real, 7) + 1j * round(x.imag, 7) for x in norm)
+
+
+def _decompose_phxz(pxz: cirq.PhasedXZGate, q: cirq.Qid) -> list[cirq.Operation] | None:
+    """Find a length<=3 sequence of {SqrtX±, S±, Pauli} matching `pxz`.
+
+    Returns None if the gate is not Clifford-reachable in this primitive set
+    (in which case the caller should leave the PhXZ in place).
+    """
+    target = cirq.unitary(pxz)
+    key = _matrix_key(target)
+    if key in _DECOMP_CACHE:
+        cached = _DECOMP_CACHE[key]
+        if cached is None:
+            return None
+        return [op.gate.on(q) for op in cached]
+
+    if cirq.equal_up_to_global_phase(target, cirq.unitary(cirq.IdentityGate(1))):
+        _DECOMP_CACHE[key] = ()
+        return []
+
+    primitives = _primitive_ops(q)
+    for op in primitives:
+        if cirq.equal_up_to_global_phase(target, cirq.unitary(op)):
+            _DECOMP_CACHE[key] = (op,)
+            return [op]
+    for op1 in primitives:
+        for op2 in primitives:
+            u = cirq.unitary(cirq.Circuit([op1, op2]))
+            if cirq.equal_up_to_global_phase(target, u):
+                _DECOMP_CACHE[key] = (op1, op2)
+                return [op1, op2]
+    for op1 in primitives:
+        for op2 in primitives:
+            for op3 in primitives:
+                u = cirq.unitary(cirq.Circuit([op1, op2, op3]))
+                if cirq.equal_up_to_global_phase(target, u):
+                    _DECOMP_CACHE[key] = (op1, op2, op3)
+                    return [op1, op2, op3]
+    _DECOMP_CACHE[key] = None
+    return None
+
+
+def _decompose_circuit(circuit: cirq.Circuit) -> cirq.Circuit:
+    new_ops = []
+    for moment in circuit:
+        for op in moment.operations:
+            gate = op.gate
+            if isinstance(gate, cirq.PhasedXZGate):
+                decomp = _decompose_phxz(gate, op.qubits[0])
+                if decomp is None:
+                    new_ops.append(op)
+                else:
+                    new_ops.extend(decomp)
+            else:
+                new_ops.append(op)
+    return cirq.Circuit(new_ops)
+
+
+def _strip_identities(circuit: cirq.Circuit) -> cirq.Circuit:
+    """Drop any cirq.I or IdentityGate ops; load_circuit can't lower them."""
+    new_moments = []
+    for m in circuit:
+        ops = [op for op in m.operations if not isinstance(op.gate, cirq.IdentityGate)]
+        if ops:
+            new_moments.append(cirq.Moment(ops))
+    return cirq.Circuit(new_moments)
+
+
+# Pauli frame propagation through the primitive gate set.
+# Conjugation tables (unsigned — we only track Pauli identity, not phase,
+# so the daggered primitives share the table of their positive form).
+_CONJ_SQRT_X = {"I": "I", "X": "X", "Y": "Z", "Z": "Y"}
+_CONJ_SQRT_Y = {"I": "I", "X": "Z", "Y": "Y", "Z": "X"}
+_CONJ_S = {"I": "I", "X": "Y", "Y": "X", "Z": "Z"}
+
+_PAULI_MULT = {
+    ("I", "I"): "I",
+    ("I", "X"): "X",
+    ("I", "Y"): "Y",
+    ("I", "Z"): "Z",
+    ("X", "I"): "X",
+    ("X", "X"): "I",
+    ("X", "Y"): "Z",
+    ("X", "Z"): "Y",
+    ("Y", "I"): "Y",
+    ("Y", "X"): "Z",
+    ("Y", "Y"): "I",
+    ("Y", "Z"): "X",
+    ("Z", "I"): "Z",
+    ("Z", "X"): "Y",
+    ("Z", "Y"): "X",
+    ("Z", "Z"): "I",
+}
+
+_PAULI_GATE = {"X": cirq.X, "Y": cirq.Y, "Z": cirq.Z}
+
+
+def _eject_paulis_through_primitives(circuit: cirq.Circuit) -> cirq.Circuit:
+    """Push body Paulis to a trailing layer AND sign-collapse daggered
+    primitives.
+
+    Walks `circuit` (which after decomposition has only {Pauli, SqrtX±, S±,
+    SqrtY±, CZ}). For each daggered primitive, emits the positive version
+    plus a Pauli into the frame:
+      SqrtX† -> SqrtX, frame *= X
+      SqrtY† -> SqrtY, frame *= Y
+      S†     -> S,     frame *= Z
+    Then conjugates the Pauli frame through subsequent Cliffords and
+    propagates through CZ. Emits a trailing Pauli layer at the end.
+    Result body contains only {SqrtX, SqrtY, S, CZ}.
+    """
+    qubits = sorted(circuit.all_qubits(), key=lambda q: q.x)
+    frame: dict[cirq.Qid, str] = {q: "I" for q in qubits}
+    new_ops: list[cirq.Operation] = []
+
+    conj_table = {
+        "SqrtX": _CONJ_SQRT_X,
+        "SqrtY": _CONJ_SQRT_Y,
+        "S": _CONJ_S,
+    }
+    # When emitting the positive version of a daggered primitive, the
+    # discrepancy is this Pauli (left-multiplied into the frame BEFORE
+    # the positive op fires).
+    sign_compensation = {
+        "SqrtXDag": ("SqrtX", "X"),
+        "SqrtYDag": ("SqrtY", "Y"),
+        "SDag": ("S", "Z"),
+    }
+
+    for moment in circuit:
+        for op in moment.operations:
+            label = _gate_label(op)
+            if label in ("X", "Y", "Z"):
+                q = op.qubits[0]
+                frame[q] = _PAULI_MULT[(frame[q], label)]
+            elif label in sign_compensation:
+                # Daggered primitive: emit positive form, push the Pauli
+                # compensation into the frame (it gets propagated forward
+                # by subsequent conjugations).
+                q = op.qubits[0]
+                pos_label, comp_pauli = sign_compensation[label]
+                # frame_new = comp_pauli · (positive op) · frame_old · (positive op)†
+                # Since the positive op conjugates the existing frame, do
+                # the conjugation first, then multiply by comp_pauli.
+                frame[q] = conj_table[pos_label][frame[q]]
+                frame[q] = _PAULI_MULT[(comp_pauli, frame[q])]
+                pos_gate = {
+                    "SqrtX": cirq.X**0.5,
+                    "SqrtY": cirq.Y**0.5,
+                    "S": cirq.S,
+                }[pos_label]
+                new_ops.append(pos_gate(q))
+            elif label in conj_table:
+                q = op.qubits[0]
+                frame[q] = conj_table[label][frame[q]]
+                new_ops.append(op)
+            elif op.gate == cirq.CZ:
+                q1, q2 = op.qubits
+                p1, p2 = frame[q1], frame[q2]
+                # X/Y on one qubit induces Z on the other through CZ.
+                new_p1, new_p2 = p1, p2
+                if p1 in ("X", "Y"):
+                    new_p2 = _PAULI_MULT[(new_p2, "Z")]
+                if p2 in ("X", "Y"):
+                    new_p1 = _PAULI_MULT[(new_p1, "Z")]
+                frame[q1], frame[q2] = new_p1, new_p2
+                new_ops.append(op)
+            else:
+                # Unrecognized — leave it where it is. Conservative: flush
+                # the pauli_frame before so the unrecognized op sees the
+                # right state.
+                for q, p in frame.items():
+                    if p != "I":
+                        new_ops.append(_PAULI_GATE[p](q))
+                        frame[q] = "I"
+                new_ops.append(op)
+
+    # Emit the trailing Pauli layer.
+    for q in qubits:
+        if frame[q] != "I":
+            new_ops.append(_PAULI_GATE[frame[q]](q))
+
+    return cirq.Circuit(new_ops)
+
+
+def _normalize(circuit: cirq.Circuit) -> cirq.Circuit:
+    # The eject passes are load-bearing for quality, not just cosmetic:
+    # they commute Z-rotations and Paulis toward the end BEFORE the PhXZ
+    # merge, which leaves merge_single_qubit_gates_to_phxz with fewer and
+    # simpler 1q clusters. Measured on 6q/8-layer random brickwork:
+    # removing them costs 2-10 extra 1q-parallel layers after LayerOptimize.
+    c = cirq.eject_z(circuit)
+    c = cirq.eject_phased_paulis(c)
+    c = cirq.eject_z(c)
+    c = cirq.merge_single_qubit_gates_to_phxz(c)
+    c = _decompose_circuit(c)
+    c = _strip_identities(c)
+    # Push any Paulis my decomposition emitted (e.g. H -> SqrtY + X)
+    # to a single trailing Pauli layer.
+    c = _eject_paulis_through_primitives(c)
+    return c
+
+
+def load_normalized(mt: ir.Method, circuit: cirq.Circuit) -> None:
+    """Load a normalized cirq circuit back into `mt`, in canonical squin form.
+
+    Shared by CliffordNormalize and LayerOptimize: load_circuit emits
+    Rx(±π/2) rather than SqrtX, so canonicalize via SquinU3ToClifford, then
+    ConstantFold + CSE collapse each `q[i]` to a single SSA value.
+    """
+    new_mt = load_circuit(circuit, kernel_name=mt.sym_name, dialects=mt.dialects)
+    mt.code = new_mt.code
+    Walk(SquinU3ToClifford()).rewrite(mt.code)
+    cleanup = Chain(ConstantFold(), CommonSubexpressionElimination())
+    Fixpoint(Walk(cleanup)).rewrite(mt.code)
+
+
+@dataclass
+class CliffordNormalize(Pass):
+    """Normalize a Clifford circuit to {SqrtX±, S±, CZ} + trailing Paulis."""
+
+    def unsafe_run(self, mt: ir.Method) -> abc.RewriteResult:
+        """Normalize ``mt`` in place to the Clifford primitive set."""
+        load_normalized(mt, _normalize(emit_circuit(mt)))
+        return abc.RewriteResult(has_done_something=True)

--- a/src/bloqade/squin/passes/layer_optimize.py
+++ b/src/bloqade/squin/passes/layer_optimize.py
@@ -4,7 +4,8 @@ Pipeline (one cirq round-trip):
   1. emit_circuit + _normalize: squin IR -> canonical cirq circuit.
   2. optimize_threshold_accept: bounded-uphill frame search scored by the fast
      predicted layer count.
-  3. Materialize the best frame (apply_schedule + eject + simplify); fall back to
+  3. Materialize the best frame (apply_schedule + eject + simplify + eject, so
+     Paulis simplify_diagonals emits also land at the end); fall back to
      the unframed circuit if the best frame does not beat it (no-regression
      guard — the only two full-pipeline counts).
   4. load_normalized + ParallelizeLayer.
@@ -57,8 +58,13 @@ class LayerOptimize(Pass):
             sched = optimize_threshold_accept(
                 c_norm, layer_data, qubits, _eject_paulis_through_primitives
             )
-            best = simplify_diagonals(
-                _eject_paulis_through_primitives(apply_schedule(c_norm, sched))
+            # simplify_diagonals can emit a fresh Z (a diagonal run netting to
+            # 2 mod 4) mid-circuit, so eject once more to land it in the
+            # trailing Pauli layer.
+            best = _eject_paulis_through_primitives(
+                simplify_diagonals(
+                    _eject_paulis_through_primitives(apply_schedule(c_norm, sched))
+                )
             )
             if _realized_layers(best) < _realized_layers(chosen):
                 chosen = best

--- a/src/bloqade/squin/passes/layer_optimize.py
+++ b/src/bloqade/squin/passes/layer_optimize.py
@@ -1,0 +1,66 @@
+"""LayerOptimize: reduce the 1q-parallel layer count of a Clifford circuit.
+
+Pipeline (one cirq round-trip):
+  1. emit_circuit + _normalize: squin IR -> canonical cirq circuit.
+  2. optimize_threshold_accept: bounded-uphill frame search scored by the fast
+     predicted layer count.
+  3. Materialize the best frame (apply_schedule + eject + simplify); fall back to
+     the unframed circuit if the best frame does not beat it (no-regression
+     guard — the only two full-pipeline counts).
+  4. load_normalized + ParallelizeLayer.
+"""
+
+from dataclasses import dataclass
+
+from kirin import ir
+from kirin.passes import Pass
+from kirin.rewrite import abc
+
+from bloqade.squin import gate
+from bloqade.cirq_utils import emit_circuit, load_circuit
+from bloqade.squin.passes.parallelize import ParallelizeLayer
+from bloqade.squin.layer_optimizer.search import optimize_threshold_accept
+from bloqade.squin.layer_optimizer.schedule import apply_schedule, extract_layers
+from bloqade.squin.layer_optimizer.simplify import simplify_diagonals
+from bloqade.squin.passes.clifford_normalize import (
+    _normalize,
+    load_normalized,
+    _eject_paulis_through_primitives,
+)
+
+_PAULI = (gate.stmts.X, gate.stmts.Y, gate.stmts.Z)
+
+
+def _realized_layers(circuit) -> int:
+    """Number of 1q pulse layers ParallelizeLayer produces for `circuit`."""
+    mt = load_circuit(circuit)
+    ParallelizeLayer(mt.dialects)(mt)
+    return sum(
+        1
+        for s in mt.callable_region.blocks[0].stmts
+        if isinstance(s, gate.stmts.Gate)
+        and not isinstance(s, _PAULI)
+        and not isinstance(s, gate.stmts.ControlledGate)
+    )
+
+
+@dataclass
+class LayerOptimize(Pass):
+    """Reduce 1q-parallel layer count for a Clifford circuit (CZ layers fixed)."""
+
+    def unsafe_run(self, mt: ir.Method) -> abc.RewriteResult:
+        """Run the layer optimizer on ``mt`` in place."""
+        c_norm = _normalize(emit_circuit(mt))
+        layer_data, _, qubits = extract_layers(c_norm)
+        chosen = _eject_paulis_through_primitives(c_norm)
+        if layer_data:
+            sched = optimize_threshold_accept(
+                c_norm, layer_data, qubits, _eject_paulis_through_primitives
+            )
+            best = simplify_diagonals(
+                _eject_paulis_through_primitives(apply_schedule(c_norm, sched))
+            )
+            if _realized_layers(best) < _realized_layers(chosen):
+                chosen = best
+        load_normalized(mt, chosen)
+        return ParallelizeLayer(self.dialects, no_raise=self.no_raise).unsafe_run(mt)

--- a/src/bloqade/squin/passes/parallelize.py
+++ b/src/bloqade/squin/passes/parallelize.py
@@ -210,16 +210,52 @@ class ParallelizeLayer(Pass):
                     dq.append(m)
         return depth
 
+    @staticmethod
+    def _trailing_paulis(ids, out, is_pauli) -> set:
+        """Pauli nodes whose every successor is itself a trailing Pauli.
+
+        These are the ejected Pauli frame at the very end of the circuit. They
+        are free (virtual frame, not pulse layers) and, being scheduled
+        alongside the counted gates, would otherwise perturb the greedy
+        placement order and inflate the layer count. Detected in reverse so a
+        Pauli only qualifies once all its successors are known to qualify.
+        """
+        # Fixpoint over the (short) Pauli tails: a Pauli joins `trailing` once
+        # all its successors are already in it. Sinks join on the first pass.
+        trailing: set = set()
+        changed = True
+        while changed:
+            changed = False
+            for k in ids:
+                if is_pauli[k] and k not in trailing:
+                    if all(s in trailing for s in out[k]):
+                        trailing.add(k)
+                        changed = True
+        return trailing
+
     def _level_partitions(self, block, dag, emit, entries) -> None:
         ids = list(dag.stmts.keys())
         key_of = {k: merge_key(dag.stmts[k]) for k in ids}
         is_cz = {k: isinstance(dag.stmts[k], gate_stmts.ControlledGate) for k in ids}
+        is_pauli = {
+            k: isinstance(dag.stmts[k], (gate_stmts.X, gate_stmts.Y, gate_stmts.Z))
+            for k in ids
+        }
 
         # Work on commutation-aware edges (diagonals commute through CZ) so S
         # gates can merge across CZ gaps; fall back to the raw DAG if qubits are
         # opaque.
         edges = self._commutation_edges(dag, entries)
         inc, out = edges if edges is not None else (dag.inc_edges, dag.out_edges)
+
+        # Trailing Paulis are free (virtual frame). Keep them out of the
+        # piercing graph so they neither bound nor reorder the counted gates,
+        # then pin them above every gate; this makes the counted-layer count
+        # invariant to where the ejected Pauli frame sits.
+        trailing = self._trailing_paulis(ids, out, is_pauli)
+        sched_ids = [k for k in ids if k not in trailing]
+        sub_out = {k: {s for s in out[k] if s not in trailing} for k in sched_ids}
+        sub_inc = {k: {p for p in inc[k] if p not in trailing} for k in sched_ids}
 
         # The 2q (CZ) layers are FIXED at their ASAP layer (the upstream
         # structure): parallel CZ share a layer, consecutive layers are a full
@@ -231,7 +267,18 @@ class ParallelizeLayer(Pass):
         fixed = {k: (cz_depth[k] + 1) * big for k in cz_ids}
         top = (max(cz_depth.values(), default=-1) + 2) * big
 
-        levels = pierce_into_fixed(ids, inc, out, key_of, fixed, top)
+        levels = pierce_into_fixed(sched_ids, sub_inc, sub_out, key_of, fixed, top)
+        if trailing:
+            # Schedule the free Pauli frame among itself, pinned above every
+            # counted gate. A second pierce keeps same-type Paulis merged while
+            # giving two Paulis on one qubit distinct levels (the disjoint-qubit
+            # invariant the merge rule requires).
+            t_ids = list(trailing)
+            t_inc = {k: {p for p in inc[k] if p in trailing} for k in t_ids}
+            t_out = {k: {s for s in out[k] if s in trailing} for k in t_ids}
+            t_levels = pierce_into_fixed(t_ids, t_inc, t_out, key_of, {}, len(t_ids))
+            for k in t_ids:
+                levels[k] = top + 1 + t_levels[k]
         level = {dag.stmts[k]: levels[k] for k in ids}
 
         # Reorder this block's gate statements into level order. Safe: gate

--- a/src/bloqade/squin/passes/parallelize.py
+++ b/src/bloqade/squin/passes/parallelize.py
@@ -1,0 +1,258 @@
+from collections import deque
+from dataclasses import dataclass
+
+from kirin import ir
+from kirin.passes import Pass
+from kirin.rewrite import (
+    Walk,
+    Chain,
+    Fixpoint,
+    ConstantFold,
+    DeadCodeElimination,
+    CommonSubexpressionElimination,
+    abc,
+)
+
+from bloqade.analysis import address
+from bloqade.squin.gate import stmts as gate_stmts
+from bloqade.squin.passes import (  # noqa: F401  (registers DagScheduleAnalysis impls for squin.gate)
+    _schedule_impls as _schedule_impls,
+)
+from bloqade.rewrite.passes import AggressiveUnroll
+from bloqade.squin.analysis import schedule as dag_schedule
+from bloqade.squin.rewrite.parallelize import (
+    SquinBatchBroadcastsRule,
+    merge_key,
+    pierce_into_fixed,
+)
+
+
+def _is_diagonal_1q(stmt: ir.Statement) -> bool:
+    """True for single-qubit gates that commute with CZ (Z-axis rotations)."""
+    return isinstance(stmt, (gate_stmts.S, gate_stmts.Z, gate_stmts.T, gate_stmts.Rz))
+
+
+@dataclass
+class ParallelizeLayer(Pass):
+    """Batch single-qubit squin.gate statements into the fewest global pulses,
+    treating the 2q (CZ) layers as fixed.
+
+    Pipeline:
+      1. AggressiveUnroll inlines `squin.x(q[0])`-style wrappers so gate
+         statements appear at the top level for the analysis.
+      2. ConstantFold + CSE collapse semantically-identical constants (e.g.
+         exponent literals from cirq's `visit_PhasedXZGate`) into shared SSA
+         values so the rule's SSA-identity match recognizes equal gates.
+      3. Schedule (`_level_partitions`): the CZ layers are pinned at their ASAP
+         layer — parallel CZ grouped into one layer, never split or moved — and
+         the 1q gates are pierced into the gaps between these fixed walls,
+         packing each type into the fewest layers. Diagonal 1q gates (S/S†, Z)
+         commute through CZ, so they merge across gaps.
+      4. The rule replaces each (layer, type) group's first member with a
+         combined broadcast statement and deletes the rest.
+      5. ConstantFold + DCE + CSE cleanup removes dead `ilist.New` plumbing.
+
+    SquinToNative lowering downstream emits one global pulse per merged statement
+    instead of N separate gates.
+    """
+
+    def unsafe_run(self, mt: ir.Method) -> abc.RewriteResult:
+        """Run the layer-parallelization pipeline on ``mt`` in place."""
+        result = AggressiveUnroll(self.dialects, no_raise=self.no_raise).fixpoint(mt)
+        pre_clean = Chain(ConstantFold(), CommonSubexpressionElimination())
+        result = Fixpoint(Walk(pre_clean)).rewrite(mt.code).join(result)
+        merge_groups, group_numbers = self._build_merge_groups(mt)
+        rule = SquinBatchBroadcastsRule(
+            merge_groups=merge_groups, group_numbers=group_numbers
+        )
+        result = Walk(rule).rewrite(mt.code).join(result)
+        post_clean = Chain(
+            ConstantFold(),
+            DeadCodeElimination(),
+            CommonSubexpressionElimination(),
+        )
+        return Fixpoint(Walk(post_clean)).rewrite(mt.code).join(result)
+
+    def _build_merge_groups(
+        self, mt: ir.Method
+    ) -> tuple[dict[int, list[ir.Statement]], dict[ir.Statement, int]]:
+        address_frame, _ = address.AddressAnalysis(mt.dialects).run(mt)
+        dags = dag_schedule.DagScheduleAnalysis(
+            mt.dialects, address_analysis=address_frame.entries
+        ).get_dags(mt)
+
+        merge_groups: dict[int, list[ir.Statement]] = {}
+        group_numbers: dict[ir.Statement, int] = {}
+        counter = [0]
+
+        def _emit(partitions):
+            for members in partitions:
+                if len(members) > 1:
+                    merge_groups[counter[0]] = members
+                    for s in members:
+                        group_numbers[s] = counter[0]
+                    counter[0] += 1
+
+        for block, dag in dags.items():
+            self._level_partitions(block, dag, _emit, address_frame.entries)
+
+        return merge_groups, group_numbers
+
+    @staticmethod
+    def _stmt_qubits(stmt: ir.Statement, entries) -> tuple[int, ...] | None:
+        """Resolved qubit indices a gate acts on, or None if any are opaque."""
+        if isinstance(stmt, gate_stmts.ControlledGate):
+            operands = (stmt.controls, stmt.targets)
+        else:
+            operands = (getattr(stmt, "qubits", None),)
+        qubits: list[int] = []
+        for ssa in operands:
+            if ssa is None:
+                return None
+            addr = entries.get(ssa)
+            if isinstance(addr, address.AddressReg):
+                qubits.extend(addr.data)
+            elif isinstance(addr, address.AddressQubit):
+                qubits.append(addr.data)
+            else:
+                return None
+        return tuple(qubits)
+
+    def _commutation_edges(self, dag, entries):
+        """Precedence edges with diagonal 1q gates (S/S†, Z, T, Rz) commuted
+        through CZ.
+
+        The data-dependency DAG makes every gate on a qubit serially dependent,
+        so it would order an S before a CZ before another qubit's S — but those
+        diagonal gates all commute with CZ and could be one pulse. We rebuild the
+        per-qubit precedence so a diagonal gate is bounded only by its
+        neighbouring non-diagonal gates (√X/√Y/X/Y), never by CZ. Returns
+        (inc, out) over all node-ids, or None if a gate's qubits are opaque (then
+        the caller keeps the conservative DAG).
+        """
+        ids = list(dag.stmts.keys())
+        qubits_of: dict = {}
+        for k in ids:
+            qs = self._stmt_qubits(dag.stmts[k], entries)
+            if qs is None:
+                return None
+            qubits_of[k] = qs
+
+        inc: dict = {k: set() for k in ids}
+        out: dict = {k: set() for k in ids}
+
+        def link(a, b):
+            out[a].add(b)
+            inc[b].add(a)
+
+        by_qubit: dict = {}
+        for k in sorted(ids, key=lambda k: dag.stmt_index[dag.stmts[k]]):
+            for q in qubits_of[k]:
+                by_qubit.setdefault(q, []).append(k)
+
+        for chain in by_qubit.values():
+            prev_backbone = None  # last non-diagonal gate or CZ
+            prev_wall = None  # last non-diagonal 1q gate (√/X/Y)
+            prev_diag = None  # last diagonal gate (chained for distinct levels)
+            open_diags: list = []  # diagonals awaiting their following wall
+            for k in chain:
+                if _is_diagonal_1q(dag.stmts[k]):
+                    if prev_wall is not None:
+                        link(prev_wall, k)
+                    if prev_diag is not None:
+                        link(prev_diag, k)
+                    prev_diag = k
+                    open_diags.append(k)
+                else:
+                    if prev_backbone is not None:
+                        link(prev_backbone, k)
+                    prev_backbone = k
+                    if not isinstance(dag.stmts[k], gate_stmts.ControlledGate):
+                        for d in open_diags:
+                            link(d, k)
+                        open_diags = []
+                        prev_wall = k
+        return inc, out
+
+    @staticmethod
+    def _cz_depth(dag, cz_ids, is_cz):
+        """ASAP CZ layer of each 2q gate = longest chain of 2q gates ending at
+        it (1q gates contracted out). Parallel CZ (no shared qubit) share a
+        layer; consecutive layers are ordered — the upstream CZ structure."""
+
+        def cz_succ(start):
+            res, stack, seen = set(), list(dag.out_edges[start]), set()
+            while stack:
+                m = stack.pop()
+                if m in seen:
+                    continue
+                seen.add(m)
+                if is_cz[m]:
+                    res.add(m)
+                else:
+                    stack.extend(dag.out_edges[m])
+            return res
+
+        out = {k: cz_succ(k) for k in cz_ids}
+        inc = {k: set() for k in cz_ids}
+        for k in cz_ids:
+            for m in out[k]:
+                inc[m].add(k)
+        indeg = {k: len(inc[k]) for k in cz_ids}
+        dq = deque(k for k in cz_ids if indeg[k] == 0)
+        depth = {k: 0 for k in cz_ids}
+        while dq:
+            k = dq.popleft()
+            for m in out[k]:
+                depth[m] = max(depth[m], depth[k] + 1)
+                indeg[m] -= 1
+                if indeg[m] == 0:
+                    dq.append(m)
+        return depth
+
+    def _level_partitions(self, block, dag, emit, entries) -> None:
+        ids = list(dag.stmts.keys())
+        key_of = {k: merge_key(dag.stmts[k]) for k in ids}
+        is_cz = {k: isinstance(dag.stmts[k], gate_stmts.ControlledGate) for k in ids}
+
+        # Work on commutation-aware edges (diagonals commute through CZ) so S
+        # gates can merge across CZ gaps; fall back to the raw DAG if qubits are
+        # opaque.
+        edges = self._commutation_edges(dag, entries)
+        inc, out = edges if edges is not None else (dag.inc_edges, dag.out_edges)
+
+        # The 2q (CZ) layers are FIXED at their ASAP layer (the upstream
+        # structure): parallel CZ share a layer, consecutive layers are a full
+        # BIG-wide slot apart, and they are never moved. The 1q gates are then
+        # pierced into the gaps between these immovable walls.
+        big = len(ids) + 1
+        cz_ids = [k for k in ids if is_cz[k]]
+        cz_depth = self._cz_depth(dag, cz_ids, is_cz)
+        fixed = {k: (cz_depth[k] + 1) * big for k in cz_ids}
+        top = (max(cz_depth.values(), default=-1) + 2) * big
+
+        levels = pierce_into_fixed(ids, inc, out, key_of, fixed, top)
+        level = {dag.stmts[k]: levels[k] for k in ids}
+
+        # Reorder this block's gate statements into level order. Safe: gate
+        # statements produce no SSA consumed elsewhere, and their qubit-ilist
+        # operands (defined earlier, not moved) stay before every use.
+        term = block.last_stmt
+        for stmt in sorted(
+            dag.stmts.values(), key=lambda s: (level[s], dag.stmt_index[s])
+        ):
+            stmt.detach()
+            stmt.insert_before(term)
+
+        # Group by (level, merge_key). Same-level gates are an antichain, hence
+        # on disjoint qubits — exactly what SquinBatchBroadcastsRule requires.
+        groups: dict[tuple, list[ir.Statement]] = {}
+        for k in ids:
+            stmt = dag.stmts[k]
+            key = key_of[k]
+            if key is None:
+                continue
+            groups.setdefault((level[stmt], key), []).append(stmt)
+        for members in groups.values():
+            members.sort(key=lambda s: dag.stmt_index[s])
+        emit(groups.values())

--- a/src/bloqade/squin/rewrite/__init__.py
+++ b/src/bloqade/squin/rewrite/__init__.py
@@ -1,1 +1,4 @@
+"""Rewrite rules for the squin dialect."""
+
+from .parallelize import SquinBatchBroadcastsRule as SquinBatchBroadcastsRule
 from .U3_to_clifford import SquinU3ToClifford as SquinU3ToClifford

--- a/src/bloqade/squin/rewrite/parallelize.py
+++ b/src/bloqade/squin/rewrite/parallelize.py
@@ -1,0 +1,210 @@
+from collections import deque
+from dataclasses import field, dataclass
+
+from kirin import ir
+from kirin.dialects import ilist
+from kirin.rewrite.abc import RewriteRule, RewriteResult
+
+from bloqade.squin.gate import stmts as gate_stmts
+
+
+def merge_key(stmt: ir.Statement) -> tuple | None:
+    """Return a hashable key identifying which broadcast partition a statement belongs to.
+
+    Returns None when the statement cannot be batched (unsupported type).
+    """
+    if isinstance(stmt, gate_stmts.SingleQubitNonHermitianGate):
+        return (type(stmt), stmt.adjoint)
+    if isinstance(stmt, gate_stmts.SingleQubitGate):
+        return (type(stmt),)
+    if isinstance(stmt, gate_stmts.RotationGate):
+        return (type(stmt), stmt.angle)
+    if isinstance(stmt, gate_stmts.ControlledGate):
+        return (type(stmt),)
+    if isinstance(stmt, gate_stmts.PhasedXZ):
+        return (
+            type(stmt),
+            stmt.x_exponent,
+            stmt.z_exponent,
+            stmt.axis_phase_exponent,
+        )
+    return None
+
+
+def pierce_into_fixed(
+    node_ids: list,
+    inc_edges: dict,
+    out_edges: dict,
+    key_of: dict,
+    fixed_levels: dict,
+    top: int,
+) -> dict:
+    """Place the free nodes at levels minimizing distinct (level, key) groups,
+    with the fixed nodes (e.g. CZ layers) held at given immovable levels.
+
+    Backward delay-to-merge: process nodes successors-first; place each free node
+    at the latest level in its window that already hosts its key — joining that
+    group — else at the latest feasible level. A free node's window is its
+    forward lower bound (from fixed/free predecessors) up to the min of its
+    already-placed successors (fixed walls and placed free nodes). Respects
+    precedence (level[pred] < level[succ]), so e.g. a √X never crosses a CZ on
+    its qubit while an S (whose CZ edges are dropped upstream) freely does.
+
+    Operates on plain adjacency so it is testable without IR.
+      node_ids: all node ids (free + fixed)
+      inc_edges/out_edges: id -> set of predecessor/successor ids
+      key_of: id -> merge_key (None = placed but never merged)
+      fixed_levels: id -> level for the immovable nodes
+      top: a level strictly above every fixed level (window cap for sinks)
+    Returns: id -> level for ALL nodes.
+    """
+    indeg = {n: len(inc_edges[n]) for n in node_ids}
+    dq = deque(n for n in node_ids if indeg[n] == 0)
+    order: list = []
+    while dq:
+        n = dq.popleft()
+        order.append(n)
+        for m in out_edges[n]:
+            indeg[m] -= 1
+            if indeg[m] == 0:
+                dq.append(m)
+
+    placed = dict(fixed_levels)
+    # Forward lower bound for each free node (respects fixed walls + free chains).
+    lo: dict = {}
+    for n in order:
+        if n in fixed_levels:
+            continue
+        lo[n] = max(
+            (placed[p] + 1 if p in fixed_levels else lo[p] + 1 for p in inc_edges[n]),
+            default=0,
+        )
+
+    used: dict = {}  # key -> set of used levels
+    for n in reversed(order):
+        if n in fixed_levels:
+            continue
+        k = key_of[n]
+        hi = max(min((placed[s] - 1 for s in out_edges[n]), default=top), lo[n])
+        level = None
+        if k is not None:
+            cands = [s for s in used.get(k, ()) if lo[n] <= s <= hi]
+            if cands:
+                level = max(cands)
+        if level is None:
+            level = hi
+        placed[n] = level
+        if k is not None:
+            used.setdefault(k, set()).add(level)
+
+    for n in node_ids:
+        for m in out_edges[n]:
+            if placed[n] >= placed[m]:
+                raise RuntimeError("pierce_into_fixed: precedence violated")
+    return placed
+
+
+def _ilist_values(ssa: ir.SSAValue) -> tuple[ir.SSAValue, ...] | None:
+    """Return the values of an ilist.New that produced this SSA value, or None if opaque."""
+    if isinstance(ssa, ir.ResultValue) and isinstance(ssa.stmt, ilist.New):
+        return tuple(ssa.stmt.values)
+    return None
+
+
+@dataclass
+class SquinBatchBroadcastsRule(RewriteRule):
+    """Merge same-type squin.gate statements on disjoint qubits into one broadcast.
+
+    Statements are batched according to a precomputed assignment:
+      - `merge_groups[g]` is the ordered list of statements in group `g`.
+      - `group_numbers[stmt]` is the group id for a statement (absent → not batched).
+
+    When the rule sees the first statement of a group it constructs a single replacement
+    statement whose `qubits` ilist concatenates each group member's qubits. Subsequent
+    statements in the same group are deleted.
+
+    The caller (typically `ParallelizeLayer`) is responsible for ensuring statements in
+    the same group operate on disjoint qubits. The rule raises ``ValueError`` if this
+    invariant is violated when combining qubit lists.
+    """
+
+    merge_groups: dict[int, list[ir.Statement]]
+    group_numbers: dict[ir.Statement, int]
+    group_has_merged: dict[int, bool] = field(default_factory=dict)
+
+    def rewrite_Statement(self, node: ir.Statement) -> RewriteResult:
+        """Merge ``node`` into its broadcast group, or delete it if absorbed."""
+        group_id = self.group_numbers.get(node)
+        if group_id is None:
+            return RewriteResult()
+        group = self.merge_groups[group_id]
+        if node is group[0]:
+            ok = self._merge_first(node, group)
+            self.group_has_merged[group_id] = ok
+            return RewriteResult(has_done_something=ok)
+        if self.group_has_merged.get(group_id, False):
+            node.delete()
+            return RewriteResult(has_done_something=True)
+        return RewriteResult()
+
+    def _merge_first(self, node: ir.Statement, group: list[ir.Statement]) -> bool:
+        """Build the combined broadcast statement and insert it before `node`."""
+        if isinstance(node, gate_stmts.ControlledGate):
+            return self._merge_controlled(node, group)
+        combined_qubits = self._combine_qubits([s.qubits for s in group])
+        if combined_qubits is None:
+            return False
+        new_ilist = ilist.New(values=combined_qubits)
+        new_ilist.insert_before(node)
+        new_stmt = self._build_merged(node, new_ilist.result)
+        node.replace_by(new_stmt)
+        return True
+
+    def _merge_controlled(self, node: ir.Statement, group: list[ir.Statement]) -> bool:
+        combined_ctrls = self._combine_qubits([s.controls for s in group])
+        combined_tgts = self._combine_qubits([s.targets for s in group])
+        if combined_ctrls is None or combined_tgts is None:
+            return False
+        new_ctrls = ilist.New(values=combined_ctrls)
+        new_tgts = ilist.New(values=combined_tgts)
+        new_ctrls.insert_before(node)
+        new_tgts.insert_before(node)
+        new_stmt = type(node)(controls=new_ctrls.result, targets=new_tgts.result)
+        node.replace_by(new_stmt)
+        return True
+
+    def _build_merged(
+        self, node: ir.Statement, qubits_ssa: ir.SSAValue
+    ) -> ir.Statement:
+        """Construct a replacement statement of the same type as `node` with combined qubits."""
+        cls = type(node)
+        if isinstance(node, gate_stmts.SingleQubitNonHermitianGate):
+            return cls(adjoint=node.adjoint, qubits=qubits_ssa)
+        if isinstance(node, gate_stmts.RotationGate):
+            return cls(angle=node.angle, qubits=qubits_ssa)
+        if isinstance(node, gate_stmts.PhasedXZ):
+            return cls(
+                x_exponent=node.x_exponent,
+                z_exponent=node.z_exponent,
+                axis_phase_exponent=node.axis_phase_exponent,
+                qubits=qubits_ssa,
+            )
+        return cls(qubits=qubits_ssa)
+
+    def _combine_qubits(
+        self, qubit_ssas: list[ir.SSAValue]
+    ) -> tuple[ir.SSAValue, ...] | None:
+        """Concatenate the qubit ilists of each statement, or None if any is opaque.
+
+        Asserts the result has no duplicates — the caller must guarantee the input
+        statements operate on disjoint qubits.
+        """
+        combined: list[ir.SSAValue] = []
+        for ssa in qubit_ssas:
+            values = _ilist_values(ssa)
+            if values is None:
+                return None
+            combined.extend(values)
+        if len(combined) != len(set(combined)):
+            raise ValueError("merge groups must contain statements on disjoint qubits")
+        return tuple(combined)

--- a/test/squin/layer_optimizer/test_cost.py
+++ b/test/squin/layer_optimizer/test_cost.py
@@ -1,0 +1,82 @@
+import cirq
+
+from bloqade.squin import gate
+from bloqade.cirq_utils import load_circuit
+from bloqade.squin.passes.parallelize import ParallelizeLayer
+from bloqade.squin.layer_optimizer.cost import predicted_layer_count
+
+
+def _realized(c):
+    mt = load_circuit(c)
+    ParallelizeLayer(mt.dialects)(mt)
+    return sum(
+        1
+        for s in mt.callable_region.blocks[0].stmts
+        if isinstance(s, gate.stmts.Gate)
+        and not isinstance(s, (gate.stmts.X, gate.stmts.Y, gate.stmts.Z))
+        and not isinstance(s, gate.stmts.ControlledGate)
+    )
+
+
+def _random_brickwork(n_qubits, n_cz_layers, seed):
+    import random
+
+    rng = random.Random(seed)
+    qs = cirq.LineQubit.range(n_qubits)
+    one_q = [
+        cirq.X,
+        cirq.Y,
+        cirq.Z,
+        cirq.S,
+        cirq.S**-1,
+        cirq.X**0.5,
+        cirq.X**-0.5,
+        cirq.Y**0.5,
+        cirq.Y**-0.5,
+    ]
+    moments = []
+    for layer in range(n_cz_layers):
+        ops = [rng.choice(one_q)(x) for x in qs if rng.random() < 0.7]
+        if ops:
+            moments.append(cirq.Moment(ops))
+        off = layer % 2
+        cz = [cirq.CZ(qs[i], qs[i + 1]) for i in range(off, n_qubits - 1, 2)]
+        if cz:
+            moments.append(cirq.Moment(cz))
+    return cirq.Circuit(moments)
+
+
+def test_predicted_matches_realized_simple():
+    q = cirq.LineQubit.range(2)
+    c = cirq.Circuit((cirq.X**0.5)(q[0]), (cirq.X**0.5)(q[1]), cirq.CZ(q[0], q[1]))
+    assert predicted_layer_count(c) == _realized(c) == 1
+
+
+def test_predicted_counts_distinct_types_per_gap():
+    q = cirq.LineQubit.range(2)
+    c = cirq.Circuit((cirq.X**0.5)(q[0]), (cirq.Y**0.5)(q[1]), cirq.CZ(q[0], q[1]))
+    assert predicted_layer_count(c) == _realized(c) == 2
+
+
+def test_predicted_excludes_paulis():
+    q = cirq.LineQubit.range(1)
+    c = cirq.Circuit(cirq.X(q[0]), cirq.Z(q[0]))
+    assert predicted_layer_count(c) == 0
+
+
+def test_predicted_within_one_of_realized_on_sweep():
+    """The fast cost tracks the realized count closely (off by at most 1).
+    Exactness is not required for correctness — the pass materializes through the
+    real pipeline with a no-regression guard — but a large drift would mean the
+    cost is misguiding the search."""
+    from bloqade.cirq_utils import emit_circuit
+    from bloqade.squin.passes.clifford_normalize import _normalize
+
+    max_drift = 0
+    for seed in range(4):
+        c = _random_brickwork(6, 8, seed=seed)
+        c_norm = _normalize(emit_circuit(load_circuit(c)))
+        max_drift = max(
+            max_drift, abs(predicted_layer_count(c_norm) - _realized(c_norm))
+        )
+    assert max_drift <= 1

--- a/test/squin/layer_optimizer/test_schedule.py
+++ b/test/squin/layer_optimizer/test_schedule.py
@@ -1,0 +1,84 @@
+import itertools
+
+import cirq
+
+from bloqade.squin.layer_optimizer.schedule import apply_schedule, extract_layers
+from bloqade.squin.passes.clifford_normalize import (
+    _normalize,
+    _eject_paulis_through_primitives,
+)
+
+
+def _normalized(circuit):
+    return _normalize(circuit)
+
+
+def test_extract_layers_axis_and_gaps():
+    q = cirq.LineQubit.range(2)
+    c = _normalized(
+        cirq.Circuit(
+            (cirq.X**0.5)(q[0]),
+            cirq.CZ(q[0], q[1]),
+            (cirq.X**0.5)(q[1]),
+        )
+    )
+    layer_data, s_qubits, qubits = extract_layers(c)
+    # One CZ -> two gaps, all lists aligned.
+    assert len(layer_data) == 2
+    assert len(s_qubits) == 2
+    assert len(qubits) == 2
+    # Axes are 'X' or 'Y'.
+    for gap in layer_data:
+        assert all(ax in ("X", "Y") for ax in gap.values())
+
+
+def test_apply_schedule_all_zero_is_noop_unitary():
+    q = cirq.LineQubit.range(2)
+    c = _normalized(
+        cirq.Circuit(
+            (cirq.X**0.5)(q[0]),
+            cirq.CZ(q[0], q[1]),
+            (cirq.Y**0.5)(q[1]),
+        )
+    )
+    layer_data, _, qubits = extract_layers(c)
+    schedule = [{qq: 0 for qq in qubits} for _ in range(len(layer_data) + 1)]
+    out = _eject_paulis_through_primitives(apply_schedule(c, schedule))
+    assert cirq.equal_up_to_global_phase(cirq.unitary(c), cirq.unitary(out))
+
+
+def test_apply_schedule_exhaustive_preserves_unitary():
+    """Every binary schedule must preserve the unitary (up to global phase).
+
+    Cirq op-space, so we normalize once and reuse — no per-schedule IR
+    round-trip.
+    """
+    q = cirq.LineQubit.range(2)
+    c = _normalized(
+        cirq.Circuit(
+            (cirq.X**0.5)(q[0]),
+            (cirq.X**-0.5)(q[1]),
+            cirq.CZ(q[0], q[1]),
+            (cirq.Y**0.5)(q[0]),
+            (cirq.Y**-0.5)(q[1]),
+            cirq.X(q[0]),
+            cirq.Z(q[1]),
+        )
+    )
+    u_in = cirq.unitary(c)
+    layer_data, _, qubits = extract_layers(c)
+    n_boundaries = len(layer_data) + 1
+    n = len(qubits)
+    internal = (n_boundaries - 1) * n
+    assert internal <= 12
+
+    for bits in itertools.product([0, 1], repeat=internal):
+        schedule = [{qq: 0 for qq in qubits}]
+        idx = 0
+        for _ in range(n_boundaries - 1):
+            schedule.append({qubits[j]: bits[idx + j] for j in range(n)})
+            idx += n
+        out = _eject_paulis_through_primitives(apply_schedule(c, schedule))
+        assert cirq.equal_up_to_global_phase(
+            u_in, cirq.unitary(out)
+        ), f"failed for schedule bits {bits}"

--- a/test/squin/layer_optimizer/test_search.py
+++ b/test/squin/layer_optimizer/test_search.py
@@ -1,0 +1,76 @@
+import cirq
+
+from bloqade.cirq_utils import emit_circuit, load_circuit
+from bloqade.squin.layer_optimizer.cost import predicted_layer_count
+from bloqade.squin.layer_optimizer.search import optimize_threshold_accept
+from bloqade.squin.layer_optimizer.schedule import apply_schedule, extract_layers
+from bloqade.squin.layer_optimizer.simplify import simplify_diagonals
+from bloqade.squin.passes.clifford_normalize import (
+    _normalize,
+    _eject_paulis_through_primitives,
+)
+
+
+def _random_brickwork(n_qubits, n_cz_layers, seed, p_1q=0.7):
+    import random
+
+    rng = random.Random(seed)
+    qs = cirq.LineQubit.range(n_qubits)
+    one_q = [
+        cirq.X,
+        cirq.Y,
+        cirq.Z,
+        cirq.H,
+        cirq.S,
+        cirq.S**-1,
+        cirq.X**0.5,
+        cirq.X**-0.5,
+        cirq.Y**0.5,
+        cirq.Y**-0.5,
+    ]
+    moments = []
+
+    def add_1q():
+        ops = [rng.choice(one_q)(q) for q in qs if rng.random() < p_1q]
+        if ops:
+            moments.append(cirq.Moment(ops))
+
+    for layer in range(n_cz_layers):
+        add_1q()
+        off = layer % 2
+        cz = [cirq.CZ(qs[i], qs[i + 1]) for i in range(off, n_qubits - 1, 2)]
+        if cz:
+            moments.append(cirq.Moment(cz))
+    add_1q()
+    return cirq.Circuit(moments)
+
+
+def _materialize(c_norm, sched):
+    return simplify_diagonals(
+        _eject_paulis_through_primitives(apply_schedule(c_norm, sched))
+    )
+
+
+def test_search_reaches_six_on_seed0_fast():
+    c = _random_brickwork(6, 8, seed=0)
+    c_norm = _normalize(emit_circuit(load_circuit(c)))
+    layer_data, _, qubits = extract_layers(c_norm)
+    sched = optimize_threshold_accept(
+        c_norm, layer_data, qubits, _eject_paulis_through_primitives
+    )
+    assert predicted_layer_count(_materialize(c_norm, sched)) <= 6
+
+
+def test_search_never_worse_than_zero_frame():
+    c = _random_brickwork(6, 8, seed=2)
+    c_norm = _normalize(emit_circuit(load_circuit(c)))
+    layer_data, _, qubits = extract_layers(c_norm)
+    zero = [{q: 0 for q in qubits}] + [
+        {q: 0 for q in qubits} for _ in range(len(layer_data))
+    ]
+    sched = optimize_threshold_accept(
+        c_norm, layer_data, qubits, _eject_paulis_through_primitives
+    )
+    assert predicted_layer_count(_materialize(c_norm, sched)) <= predicted_layer_count(
+        _materialize(c_norm, zero)
+    )

--- a/test/squin/layer_optimizer/test_simplify.py
+++ b/test/squin/layer_optimizer/test_simplify.py
@@ -1,0 +1,50 @@
+import cirq
+
+from bloqade.squin.layer_optimizer.simplify import simplify_diagonals
+
+
+def _s_count(c: cirq.Circuit) -> int:
+    return sum(1 for op in c.all_operations() if op.gate in (cirq.S, cirq.S**-1))
+
+
+def test_s_then_sdag_through_cz_cancels():
+    q = cirq.LineQubit.range(2)
+    c = cirq.Circuit([cirq.S(q[0]), cirq.CZ(q[0], q[1]), (cirq.S**-1)(q[0])])
+    out = simplify_diagonals(c)
+    assert _s_count(out) == 0
+    assert cirq.equal_up_to_global_phase(cirq.unitary(c), cirq.unitary(out))
+
+
+def test_s_then_s_becomes_z():
+    q = cirq.LineQubit.range(2)
+    c = cirq.Circuit([cirq.S(q[0]), cirq.CZ(q[0], q[1]), cirq.S(q[0])])
+    out = simplify_diagonals(c)
+    assert _s_count(out) == 0
+    assert any(op.gate == cirq.Z for op in out.all_operations())
+    assert cirq.equal_up_to_global_phase(cirq.unitary(c), cirq.unitary(out))
+
+
+def test_axis_gate_blocks_combination():
+    q = cirq.LineQubit.range(1)
+    c = cirq.Circuit([cirq.S(q[0]), (cirq.X**0.5)(q[0]), cirq.S(q[0])])
+    out = simplify_diagonals(c)
+    assert _s_count(out) == 2
+    assert cirq.equal_up_to_global_phase(cirq.unitary(c), cirq.unitary(out))
+
+
+def test_preserves_unitary_on_mixed_circuit():
+    q = cirq.LineQubit.range(3)
+    c = cirq.Circuit(
+        [
+            cirq.S(q[0]),
+            (cirq.Y**0.5)(q[1]),
+            cirq.CZ(q[0], q[1]),
+            (cirq.S**-1)(q[0]),
+            cirq.Z(q[2]),
+            cirq.CZ(q[1], q[2]),
+            (cirq.X**0.5)(q[0]),
+            cirq.S(q[2]),
+        ]
+    )
+    out = simplify_diagonals(c)
+    assert cirq.equal_up_to_global_phase(cirq.unitary(c), cirq.unitary(out))

--- a/test/squin/passes/test_clifford_normalize.py
+++ b/test/squin/passes/test_clifford_normalize.py
@@ -1,0 +1,81 @@
+import cirq
+
+from bloqade.squin import gate
+from bloqade.cirq_utils import emit_circuit, load_circuit
+from bloqade.squin.passes.clifford_normalize import CliffordNormalize
+
+
+def _stmt_count(mt, cls):
+    return sum(1 for s in mt.callable_region.blocks[0].stmts if isinstance(s, cls))
+
+
+def test_normalize_preserves_unitary():
+    q = cirq.LineQubit.range(3)
+    circuit = cirq.Circuit(
+        cirq.H(q[0]),
+        cirq.X(q[1]),
+        (cirq.Y**0.5)(q[2]),
+        cirq.CZ(q[0], q[1]),
+        cirq.CZ(q[1], q[2]),
+        (cirq.X**0.5)(q[0]),
+        cirq.S(q[1]) ** -1,
+        cirq.H(q[2]),
+    )
+    u_before = cirq.unitary(circuit)
+
+    mt = load_circuit(circuit)
+    CliffordNormalize(mt.dialects)(mt)
+    u_after = cirq.unitary(emit_circuit(mt))
+
+    assert cirq.equal_up_to_global_phase(u_before, u_after)
+
+
+def test_normalize_eliminates_phasedxz_for_cliffords():
+    q = cirq.LineQubit.range(2)
+    circuit = cirq.Circuit(
+        cirq.PhasedXZGate(x_exponent=0.5, z_exponent=0.5, axis_phase_exponent=0.0).on(
+            q[0]
+        ),
+        cirq.CZ(q[0], q[1]),
+    )
+
+    mt = load_circuit(circuit)
+    CliffordNormalize(mt.dialects)(mt)
+
+    assert _stmt_count(mt, gate.stmts.PhasedXZ) == 0
+
+
+def test_normalize_emits_only_sqrt_x_s_pauli_cz():
+    """Body should contain only {SqrtX, SqrtY, S, X, Y, Z, ControlledGate}."""
+    q = cirq.LineQubit.range(2)
+    circuit = cirq.Circuit(
+        cirq.H(q[0]),
+        cirq.X(q[1]),
+        cirq.CZ(q[0], q[1]),
+        (cirq.X**0.5)(q[0]),
+        (cirq.Y**0.5)(q[1]),
+    )
+
+    mt = load_circuit(circuit)
+    CliffordNormalize(mt.dialects)(mt)
+
+    allowed = (
+        gate.stmts.SqrtX,
+        gate.stmts.SqrtY,
+        gate.stmts.S,
+        gate.stmts.X,
+        gate.stmts.Y,
+        gate.stmts.Z,
+        gate.stmts.ControlledGate,
+    )
+    for s in mt.callable_region.blocks[0].stmts:
+        if isinstance(s, gate.stmts.Gate):
+            assert isinstance(s, allowed), f"unexpected stmt: {type(s).__name__}"
+
+
+def test_normalize_handles_empty_circuit():
+    q = cirq.LineQubit.range(2)
+    circuit = cirq.Circuit(cirq.CZ(q[0], q[1]))
+    mt = load_circuit(circuit)
+    CliffordNormalize(mt.dialects)(mt)
+    assert _stmt_count(mt, gate.stmts.ControlledGate) == 1

--- a/test/squin/passes/test_import_order.py
+++ b/test/squin/passes/test_import_order.py
@@ -1,0 +1,31 @@
+"""Guard against import-cycle regressions in the squin pass package.
+
+These imports must succeed in a *fresh* interpreter where nothing else has been
+imported first — otherwise a latent cycle (e.g. ``squin.analysis.schedule`` <->
+``qasm2``) only shows up for end users, not in the test suite (which loads many
+modules before any single one and so masks the ordering bug).
+"""
+
+import sys
+import subprocess
+
+import pytest
+
+_COLD_IMPORTS = [
+    "from bloqade.squin.passes import LayerOptimize, ParallelizeLayer, CliffordNormalize",
+    "import bloqade.squin.layer_optimizer.schedule",
+    "import bloqade.squin.passes.clifford_normalize",
+]
+
+
+@pytest.mark.parametrize("stmt", _COLD_IMPORTS)
+def test_cold_import_has_no_cycle(stmt: str):
+    result = subprocess.run(
+        [sys.executable, "-c", stmt],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert (
+        result.returncode == 0
+    ), f"cold import failed: {stmt}\n{result.stdout}\n{result.stderr}"

--- a/test/squin/passes/test_layer_optimize.py
+++ b/test/squin/passes/test_layer_optimize.py
@@ -1,0 +1,207 @@
+import cirq
+
+from bloqade.squin import gate
+from bloqade.cirq_utils import emit_circuit, load_circuit
+from bloqade.squin.passes.layer_optimize import LayerOptimize
+
+
+def _stmt_count(mt, cls):
+    return sum(1 for s in mt.callable_region.blocks[0].stmts if isinstance(s, cls))
+
+
+def test_layer_optimize_preserves_unitary():
+    q = cirq.LineQubit.range(2)
+    circuit = cirq.Circuit(
+        cirq.X(q[0]) ** 0.5,
+        cirq.CZ(q[0], q[1]),
+        cirq.Y(q[1]) ** 0.5,
+    )
+    u_before = cirq.unitary(circuit)
+
+    mt = load_circuit(circuit)
+    LayerOptimize(mt.dialects)(mt)
+    u_after = cirq.unitary(emit_circuit(mt))
+
+    assert cirq.equal_up_to_global_phase(u_before, u_after)
+
+
+def test_layer_optimize_eliminates_clifford_phased_xz():
+    """Clifford PhasedXZ gates get decomposed into {SqrtX, S} primitives;
+    non-Clifford PhXZ (e.g., axis_phase=0.25 which is a T-rotation) pass
+    through unchanged."""
+    q = cirq.LineQubit.range(2)
+    circuit = cirq.Circuit(
+        cirq.PhasedXZGate(x_exponent=0.5, z_exponent=0.0, axis_phase_exponent=0.0).on(
+            q[0]
+        ),
+        cirq.CZ(q[0], q[1]),
+        cirq.PhasedXZGate(x_exponent=0.5, z_exponent=0.5, axis_phase_exponent=0.0).on(
+            q[1]
+        ),
+    )
+
+    mt = load_circuit(circuit)
+    LayerOptimize(mt.dialects)(mt)
+
+    assert _stmt_count(mt, gate.stmts.PhasedXZ) == 0
+
+
+def test_layer_optimize_handles_empty_circuit():
+    """A circuit with no 1q gates should still pass without errors."""
+    q = cirq.LineQubit.range(2)
+    circuit = cirq.Circuit(cirq.CZ(q[0], q[1]))
+
+    mt = load_circuit(circuit)
+    LayerOptimize(mt.dialects)(mt)
+    # CZ should remain
+    assert _stmt_count(mt, gate.stmts.CZ) == 1
+
+
+def test_layer_optimize_preserves_unitary_on_random_circuits():
+    """For random small Clifford circuits, LayerOptimize must preserve unitary."""
+    import random
+
+    rng = random.Random(42)
+    primitives_1q = [
+        cirq.X,
+        cirq.Y,
+        cirq.Z,
+        cirq.H,
+        cirq.S,
+        cirq.S**-1,
+        cirq.X**0.5,
+        cirq.X**-0.5,
+        cirq.Y**0.5,
+        cirq.Y**-0.5,
+    ]
+
+    for trial in range(20):
+        n_qubits = rng.choice([2, 3])
+        qs = cirq.LineQubit.range(n_qubits)
+        ops = []
+        for _ in range(rng.randint(2, 5)):
+            for q in qs:
+                ops.append(rng.choice(primitives_1q)(q))
+            pairs = [(qs[i], qs[i + 1]) for i in range(n_qubits - 1)]
+            rng.shuffle(pairs)
+            for a, b in pairs[: max(1, n_qubits // 2)]:
+                ops.append(cirq.CZ(a, b))
+        for q in qs:
+            ops.append(rng.choice(primitives_1q)(q))
+
+        c = cirq.Circuit(ops)
+        u_in = cirq.unitary(c)
+        mt = load_circuit(c)
+        LayerOptimize(mt.dialects)(mt)
+        u_out = cirq.unitary(emit_circuit(mt))
+        assert cirq.equal_up_to_global_phase(
+            u_in, u_out
+        ), f"trial {trial} failed; circuit:\n{c}"
+
+
+def _random_brickwork_lo(n_qubits, n_cz_layers, seed, p_1q=0.7):
+    import random
+
+    rng = random.Random(seed)
+    qs = cirq.LineQubit.range(n_qubits)
+    one_q = [
+        cirq.X,
+        cirq.Y,
+        cirq.Z,
+        cirq.H,
+        cirq.S,
+        cirq.S**-1,
+        cirq.X**0.5,
+        cirq.X**-0.5,
+        cirq.Y**0.5,
+        cirq.Y**-0.5,
+    ]
+    moments = []
+
+    def add_1q():
+        ops = [rng.choice(one_q)(q) for q in qs if rng.random() < p_1q]
+        if ops:
+            moments.append(cirq.Moment(ops))
+
+    for layer in range(n_cz_layers):
+        add_1q()
+        off = layer % 2
+        cz = [cirq.CZ(qs[i], qs[i + 1]) for i in range(off, n_qubits - 1, 2)]
+        if cz:
+            moments.append(cirq.Moment(cz))
+    add_1q()
+    return cirq.Circuit(moments)
+
+
+def _n_1q(mt):
+    return sum(
+        1
+        for s in mt.callable_region.blocks[0].stmts
+        if isinstance(s, gate.stmts.Gate)
+        and not isinstance(s, (gate.stmts.X, gate.stmts.Y, gate.stmts.Z))
+        and not isinstance(s, gate.stmts.ControlledGate)
+    )
+
+
+def test_layer_optimize_seed0_reaches_six():
+    c = _random_brickwork_lo(6, 8, seed=0)
+    u = cirq.unitary(c)
+    mt = load_circuit(c)
+    LayerOptimize(mt.dialects)(mt)
+    assert cirq.equal_up_to_global_phase(u, cirq.unitary(emit_circuit(mt)))
+    assert _n_1q(mt) <= 6
+
+
+def test_layer_optimize_no_regression_sweep():
+    for seed in range(4):
+        c = _random_brickwork_lo(6, 8, seed=seed)
+        u = cirq.unitary(c)
+        mt = load_circuit(c)
+        LayerOptimize(mt.dialects)(mt)
+        assert cirq.equal_up_to_global_phase(u, cirq.unitary(emit_circuit(mt)))
+
+
+def test_layer_optimize_beats_or_matches_unframed_baseline():
+    """On a seed sweep, LayerOptimize never produces more 1q layers than the
+    unframed normalized baseline, and improves on average."""
+    from bloqade.squin.passes.layer_optimize import _realized_layers
+    from bloqade.squin.passes.clifford_normalize import (
+        _normalize,
+        _eject_paulis_through_primitives,
+    )
+
+    total_base = 0
+    total_opt = 0
+    for seed in range(4):
+        c = _random_brickwork_lo(6, 8, seed=seed)
+        c_norm = _normalize(emit_circuit(load_circuit(c)))
+        base = _realized_layers(_eject_paulis_through_primitives(c_norm))
+
+        mt_opt = load_circuit(c)
+        LayerOptimize(mt_opt.dialects)(mt_opt)
+        opt = _n_1q(mt_opt)
+
+        assert opt <= base, f"seed {seed}: regression {opt} > {base}"
+        total_base += base
+        total_opt += opt
+
+    assert total_opt < total_base
+
+
+def test_layer_optimize_preserves_unitary_multilayer():
+    """LayerOptimize preserves the unitary on a multi-layer circuit with merge
+    opportunities."""
+    q = cirq.LineQubit.range(3)
+    c = cirq.Circuit(
+        [
+            (cirq.X**0.5)(q[2]),
+            cirq.CZ(q[0], q[1]),
+            (cirq.X**0.5)(q[0]),
+            cirq.CZ(q[1], q[2]),
+            (cirq.Y**0.5)(q[0]),
+        ]
+    )
+    u = cirq.unitary(c)
+    mt = load_circuit(c)
+    LayerOptimize(mt.dialects)(mt)
+    assert cirq.equal_up_to_global_phase(u, cirq.unitary(emit_circuit(mt)))

--- a/test/squin/passes/test_layer_optimize.py
+++ b/test/squin/passes/test_layer_optimize.py
@@ -205,3 +205,40 @@ def test_layer_optimize_preserves_unitary_multilayer():
     mt = load_circuit(c)
     LayerOptimize(mt.dialects)(mt)
     assert cirq.equal_up_to_global_phase(u, cirq.unitary(emit_circuit(mt)))
+
+
+def test_layer_optimize_keeps_paulis_trailing():
+    """simplify_diagonals can emit a fresh Z when a diagonal run nets to 2 mod 4;
+    the pass must eject it so all Paulis stay in the trailing layer (no Pauli
+    followed by a non-Pauli on the same qubit)."""
+    q = cirq.LineQubit.range(3)
+    # S,S on q0 nets to Z; the CZ then an axis gate force a mid-circuit flush
+    # inside simplify_diagonals.
+    c = cirq.Circuit(
+        [
+            cirq.S(q[0]),
+            cirq.S(q[0]),
+            cirq.CZ(q[0], q[1]),
+            (cirq.X**0.5)(q[0]),
+            cirq.CZ(q[1], q[2]),
+            (cirq.Y**0.5)(q[1]),
+        ]
+    )
+    u = cirq.unitary(c)
+    mt = load_circuit(c)
+    LayerOptimize(mt.dialects)(mt)
+    out = emit_circuit(mt)
+    assert cirq.equal_up_to_global_phase(u, cirq.unitary(out))
+
+    pauli = (cirq.X, cirq.Y, cirq.Z)
+    for qb in out.all_qubits():
+        seen_pauli = False
+        for moment in out:
+            op = moment.operation_at(qb)
+            if op is None:
+                continue
+            is_pauli = op.gate in pauli
+            assert not (
+                seen_pauli and not is_pauli
+            ), f"non-Pauli after Pauli on {qb} in:\n{out}"
+            seen_pauli = seen_pauli or is_pauli

--- a/test/squin/passes/test_parallelize_pass.py
+++ b/test/squin/passes/test_parallelize_pass.py
@@ -1,0 +1,178 @@
+import cirq
+from kirin import ir
+
+from bloqade import squin
+from bloqade.squin import gate
+from bloqade.analysis import address
+from bloqade.cirq_utils import emit_circuit, load_circuit
+from bloqade.squin.passes.parallelize import ParallelizeLayer
+
+
+def _stmt_count(mt: ir.Method, cls) -> int:
+    return sum(1 for s in mt.callable_region.blocks[0].stmts if isinstance(s, cls))
+
+
+def _n_1q(mt: ir.Method) -> int:
+    """Count of 1q (non-CZ) gate statements — the parallel-pulse layer count."""
+    return sum(
+        1
+        for s in mt.callable_region.blocks[0].stmts
+        if isinstance(s, gate.stmts.Gate)
+        and not isinstance(s, gate.stmts.ControlledGate)
+    )
+
+
+def test_pass_merges_parallel_x_gates_via_dag_analysis():
+    @squin.kernel
+    def test():
+        q = squin.qalloc(3)
+        squin.x(q[0])
+        squin.x(q[1])
+        squin.x(q[2])
+
+    ParallelizeLayer(test.dialects)(test)
+    assert _stmt_count(test, gate.stmts.X) == 1, "all three X should collapse into one"
+    _, _ = address.AddressAnalysis(test.dialects).run(test)
+
+
+def test_pass_does_not_merge_across_cz_barrier():
+    @squin.kernel
+    def test():
+        q = squin.qalloc(3)
+        squin.x(q[0])
+        squin.cz(q[0], q[1])
+        # Both q[0] and q[1] now depend on the CZ; second X on q[1] is in a later
+        # topological layer than the first X on q[0]. They must not merge.
+        squin.x(q[1])
+
+    ParallelizeLayer(test.dialects)(test)
+    assert _stmt_count(test, gate.stmts.X) == 2
+    assert _stmt_count(test, gate.stmts.CZ) == 1
+
+
+def test_load_circuit_then_parallelize_collapses_moments():
+    q = cirq.LineQubit.range(4)
+    circuit = cirq.Circuit(
+        cirq.Moment([cirq.X(q[i]) for i in range(4)]),
+        cirq.Moment([cirq.S(q[i]) for i in range(4)]),
+    )
+
+    mt = load_circuit(circuit)
+    assert _stmt_count(mt, gate.stmts.X) == 4
+    assert _stmt_count(mt, gate.stmts.S) == 4
+
+    ParallelizeLayer(mt.dialects)(mt)
+
+    assert _stmt_count(mt, gate.stmts.X) == 1
+    assert _stmt_count(mt, gate.stmts.S) == 1
+
+
+def test_load_circuit_phased_xz_moments_merge_after_pass():
+    """Replicates the real layer-optimizer use case: cirq emits PhasedXZ per qubit
+    with separate py.Constant SSAs; the CSE pre-step inside ParallelizeLayer
+    collapses identical exponents so the gates merge."""
+
+    q = cirq.LineQubit.range(3)
+    pxz = cirq.PhasedXZGate(x_exponent=0.5, z_exponent=0.25, axis_phase_exponent=0.125)
+    circuit = cirq.Circuit(cirq.Moment([pxz.on(qi) for qi in q]))
+
+    mt = load_circuit(circuit)
+    assert _stmt_count(mt, gate.stmts.PhasedXZ) == 3
+
+    ParallelizeLayer(mt.dialects)(mt)
+    assert _stmt_count(mt, gate.stmts.PhasedXZ) == 1
+
+
+def test_pass_preserves_address_analysis():
+    """After the pass, SSA references must still resolve cleanly."""
+
+    q = cirq.LineQubit.range(4)
+    circuit = cirq.Circuit(
+        cirq.Moment([cirq.X(q[i]) for i in range(4)]),
+        cirq.Moment([cirq.CZ(q[0], q[1]), cirq.CZ(q[2], q[3])]),
+        cirq.Moment([cirq.Y(q[i]) for i in range(4)]),
+    )
+    mt = load_circuit(circuit)
+    ParallelizeLayer(mt.dialects)(mt)
+
+    # Sanity: address analysis still resolves cleanly (no broken SSA references).
+    _, _ = address.AddressAnalysis(mt.dialects).run(mt)
+    # Sanity: each axis pulse collapsed to one statement, CZs collapsed too.
+    assert _stmt_count(mt, gate.stmts.X) == 1
+    assert _stmt_count(mt, gate.stmts.Y) == 1
+    assert _stmt_count(mt, gate.stmts.CZ) == 1
+
+
+def test_merges_same_type_1q_within_a_gap():
+    """Two √X before the same CZ layer (disjoint qubits) merge into one pulse;
+    the CZ stays a single statement."""
+
+    @squin.kernel
+    def k():
+        q = squin.qalloc(2)
+        squin.sqrt_x([q[0]])
+        squin.sqrt_x([q[1]])
+        squin.cz(q[0], q[1])
+
+    ParallelizeLayer(k.dialects)(k)
+    assert _stmt_count(k, gate.stmts.SqrtX) == 1
+    assert _stmt_count(k, gate.stmts.CZ) == 1
+
+
+def test_merges_s_across_cz():
+    """S commutes through CZ, so two S gates separated only by a CZ merge into
+    one pulse."""
+    q = cirq.LineQubit.range(2)
+    c = cirq.Circuit(
+        [
+            cirq.S(q[0]),
+            cirq.CZ(q[0], q[1]),
+            cirq.S(q[1]),
+        ]
+    )
+    u = cirq.unitary(c)
+
+    mt = load_circuit(c)
+    ParallelizeLayer(mt.dialects)(mt)
+
+    assert cirq.equal_up_to_global_phase(u, cirq.unitary(emit_circuit(mt)))
+    assert _stmt_count(mt, gate.stmts.S) == 1
+
+
+def test_reduces_1q_layers_over_a_sweep_and_preserves_unitary():
+    """Across a brickwork sweep, the pass merges 1q gates (far fewer 1q layers
+    than the unmerged input) and preserves the unitary on every circuit."""
+    one_q = [cirq.S, cirq.X**0.5, cirq.Y**0.5, cirq.Z, cirq.X]
+
+    for seed in range(5):
+        rng = cirq.value.parse_random_state(seed)
+        qs = cirq.LineQubit.range(6)
+        ops = []
+        n_1q_in = 0
+        for layer in range(6):
+            for x in qs:
+                ops.append(one_q[rng.randint(len(one_q))](x))
+                n_1q_in += 1
+            for i in range(layer % 2, 5, 2):
+                ops.append(cirq.CZ(qs[i], qs[i + 1]))
+        c = cirq.Circuit(ops)
+        u = cirq.unitary(c)
+
+        mt = load_circuit(c)
+        ParallelizeLayer(mt.dialects)(mt)
+        assert cirq.equal_up_to_global_phase(u, cirq.unitary(emit_circuit(mt)))
+        assert _n_1q(mt) < n_1q_in
+
+
+def test_groups_parallel_cz_into_one_fixed_layer():
+    """Parallel (disjoint) CZ are scheduled into one fixed CZ layer — a single
+    broadcast statement — rather than fragmented across layers."""
+
+    @squin.kernel
+    def k():
+        q = squin.qalloc(4)
+        squin.cz(q[0], q[1])
+        squin.cz(q[2], q[3])  # independent of the first — same fixed layer
+
+    ParallelizeLayer(k.dialects)(k)
+    assert _stmt_count(k, gate.stmts.CZ) == 1

--- a/test/squin/passes/test_parallelize_pass.py
+++ b/test/squin/passes/test_parallelize_pass.py
@@ -164,6 +164,51 @@ def test_reduces_1q_layers_over_a_sweep_and_preserves_unitary():
         assert _n_1q(mt) < n_1q_in
 
 
+def _n_1q_counted(mt: ir.Method) -> int:
+    """1q (non-CZ) gate statements excluding Paulis — the pulse-layer metric."""
+    return sum(
+        1
+        for s in mt.callable_region.blocks[0].stmts
+        if isinstance(s, gate.stmts.Gate)
+        and not isinstance(s, gate.stmts.ControlledGate)
+        and not isinstance(s, (gate.stmts.X, gate.stmts.Y, gate.stmts.Z))
+    )
+
+
+def test_trailing_paulis_do_not_inflate_layer_count():
+    """The ejected Pauli frame is free: appending a trailing Pauli layer must
+    not change the counted (non-Pauli) 1q-layer count. Without this the greedy
+    scheduler would let trailing Paulis perturb where counted gates land."""
+    one_q = [cirq.S, cirq.X**0.5, cirq.Y**0.5]
+    for seed in range(6):
+        rng = cirq.value.parse_random_state(seed)
+        qs = cirq.LineQubit.range(5)
+        ops = []
+        for layer in range(6):
+            for x in qs:
+                ops.append(one_q[rng.randint(len(one_q))](x))
+            for i in range(layer % 2, 4, 2):
+                ops.append(cirq.CZ(qs[i], qs[i + 1]))
+
+        bare = cirq.Circuit(ops)
+        with_frame = cirq.Circuit(
+            ops + [[cirq.X, cirq.Y, cirq.Z][rng.randint(3)](x) for x in qs]
+        )
+
+        mt_bare = load_circuit(bare)
+        ParallelizeLayer(mt_bare.dialects)(mt_bare)
+        mt_frame = load_circuit(with_frame)
+        ParallelizeLayer(mt_frame.dialects)(mt_frame)
+
+        assert _n_1q_counted(mt_frame) == _n_1q_counted(mt_bare), (
+            f"seed {seed}: trailing Paulis changed counted layers "
+            f"{_n_1q_counted(mt_bare)} -> {_n_1q_counted(mt_frame)}"
+        )
+        assert cirq.equal_up_to_global_phase(
+            cirq.unitary(with_frame), cirq.unitary(emit_circuit(mt_frame))
+        )
+
+
 def test_groups_parallel_cz_into_one_fixed_layer():
     """Parallel (disjoint) CZ are scheduled into one fixed CZ layer — a single
     broadcast statement — rather than fragmented across layers."""

--- a/test/squin/rewrite/test_parallelize_rule.py
+++ b/test/squin/rewrite/test_parallelize_rule.py
@@ -1,0 +1,335 @@
+from kirin import ir
+from kirin.rewrite import Walk
+from kirin.dialects import ilist
+
+from bloqade import squin
+from bloqade.squin import gate
+from bloqade.rewrite.passes import AggressiveUnroll
+from bloqade.squin.rewrite.parallelize import (
+    SquinBatchBroadcastsRule,
+    merge_key,
+    pierce_into_fixed,
+)
+
+
+def _gate_stmts(mt: ir.Method, cls) -> list[ir.Statement]:
+    return [s for s in mt.callable_region.blocks[0].stmts if isinstance(s, cls)]
+
+
+def _build_rule_simple(mt: ir.Method) -> SquinBatchBroadcastsRule:
+    """Test helper: group every same-type gate stmt into one merge group.
+
+    Caller must ensure the input kernel has only disjoint-qubit gates of each type
+    (the rule itself asserts disjointness when it merges).
+    """
+    by_type: dict[type, list[ir.Statement]] = {}
+    for s in mt.callable_region.blocks[0].stmts:
+        if isinstance(s, gate.stmts.Gate):
+            by_type.setdefault(type(s), []).append(s)
+    merge_groups: dict[int, list[ir.Statement]] = {}
+    group_numbers: dict[ir.Statement, int] = {}
+    for i, group in enumerate(by_type.values()):
+        if len(group) > 1:
+            merge_groups[i] = group
+            for s in group:
+                group_numbers[s] = i
+    return SquinBatchBroadcastsRule(
+        merge_groups=merge_groups, group_numbers=group_numbers
+    )
+
+
+def test_smoke_kernel_lowers_to_gate_stmts_after_unroll():
+    """Confirms: `squin.x(q[0])` + AggressiveUnroll produces gate.stmts.X at the top level."""
+
+    @squin.kernel
+    def test():
+        q = squin.qalloc(2)
+        squin.x(q[0])
+        squin.x(q[1])
+
+    AggressiveUnroll(test.dialects).fixpoint(test)
+
+    xs = _gate_stmts(test, gate.stmts.X)
+    assert len(xs) == 2, "expected two X stmts at the top level after inlining"
+    # Each X holds a single-qubit ilist
+    for x in xs:
+        assert isinstance(x.qubits.owner, ilist.New)
+        assert len(x.qubits.owner.values) == 1
+
+
+def test_two_x_on_disjoint_qubits_merge():
+    @squin.kernel
+    def test():
+        q = squin.qalloc(2)
+        squin.x(q[0])
+        squin.x(q[1])
+
+    AggressiveUnroll(test.dialects).fixpoint(test)
+    rule = _build_rule_simple(test)
+    Walk(rule).rewrite(test.code)
+
+    xs = _gate_stmts(test, gate.stmts.X)
+    assert len(xs) == 1, "two X stmts should collapse to one"
+    qubits_stmt = xs[0].qubits.owner
+    assert isinstance(qubits_stmt, ilist.New)
+    assert len(qubits_stmt.values) == 2
+
+
+def test_y_z_h_all_merge_similarly():
+    @squin.kernel
+    def test():
+        q = squin.qalloc(2)
+        squin.y(q[0])
+        squin.y(q[1])
+        squin.z(q[0])
+        squin.z(q[1])
+        squin.h(q[0])
+        squin.h(q[1])
+
+    AggressiveUnroll(test.dialects).fixpoint(test)
+    rule = _build_rule_simple(test)
+    Walk(rule).rewrite(test.code)
+
+    assert len(_gate_stmts(test, gate.stmts.Y)) == 1
+    assert len(_gate_stmts(test, gate.stmts.Z)) == 1
+    assert len(_gate_stmts(test, gate.stmts.H)) == 1
+
+
+def test_different_types_do_not_merge():
+    @squin.kernel
+    def test():
+        q = squin.qalloc(2)
+        squin.x(q[0])
+        squin.y(q[1])
+
+    AggressiveUnroll(test.dialects).fixpoint(test)
+    rule = _build_rule_simple(test)
+    Walk(rule).rewrite(test.code)
+
+    # Different types live in different groups (none with size > 1), so no merging.
+    assert len(_gate_stmts(test, gate.stmts.X)) == 1
+    assert len(_gate_stmts(test, gate.stmts.Y)) == 1
+
+
+def _build_rule_keyed(
+    mt: ir.Method, attr_names_by_type: dict[type, tuple[str, ...]]
+) -> SquinBatchBroadcastsRule:
+    """Test helper: group stmts by (type, *attr_values) — for non-Hermitian and parameterized gates."""
+    groups: dict[tuple, list[ir.Statement]] = {}
+    for s in mt.callable_region.blocks[0].stmts:
+        if not isinstance(s, gate.stmts.Gate):
+            continue
+        attr_names = attr_names_by_type.get(type(s), ())
+        key = (type(s),) + tuple(getattr(s, n) for n in attr_names)
+        groups.setdefault(key, []).append(s)
+    merge_groups: dict[int, list[ir.Statement]] = {}
+    group_numbers: dict[ir.Statement, int] = {}
+    for i, group in enumerate(groups.values()):
+        if len(group) > 1:
+            merge_groups[i] = group
+            for s in group:
+                group_numbers[s] = i
+    return SquinBatchBroadcastsRule(
+        merge_groups=merge_groups, group_numbers=group_numbers
+    )
+
+
+def test_same_adjoint_s_gates_merge():
+    @squin.kernel
+    def test():
+        q = squin.qalloc(2)
+        squin.s(q[0])
+        squin.s(q[1])
+
+    AggressiveUnroll(test.dialects).fixpoint(test)
+    rule = _build_rule_keyed(test, attr_names_by_type={gate.stmts.S: ("adjoint",)})
+    Walk(rule).rewrite(test.code)
+    ss = _gate_stmts(test, gate.stmts.S)
+    assert len(ss) == 1
+    assert ss[0].adjoint is False
+
+
+def test_different_adjoint_s_gates_do_not_merge():
+    @squin.kernel
+    def test():
+        q = squin.qalloc(2)
+        squin.s(q[0])
+        squin.s_adj(q[1])
+
+    AggressiveUnroll(test.dialects).fixpoint(test)
+    rule = _build_rule_keyed(test, attr_names_by_type={gate.stmts.S: ("adjoint",)})
+    Walk(rule).rewrite(test.code)
+    ss = _gate_stmts(test, gate.stmts.S)
+    assert len(ss) == 2, "S(False) and S(True) must not merge"
+
+
+def test_merge_key_distinguishes_adjoint():
+    @squin.kernel
+    def test():
+        q = squin.qalloc(2)
+        squin.s(q[0])
+        squin.s_adj(q[1])
+
+    AggressiveUnroll(test.dialects).fixpoint(test)
+    s_stmts = _gate_stmts(test, gate.stmts.S)
+    assert len(s_stmts) == 2
+    assert merge_key(s_stmts[0]) != merge_key(s_stmts[1])
+    keys = {merge_key(s) for s in s_stmts}
+    assert (gate.stmts.S, False) in keys
+    assert (gate.stmts.S, True) in keys
+
+
+def test_merge_key_unsupported_returns_none():
+    @squin.kernel
+    def test():
+        squin.qalloc(1)
+
+    AggressiveUnroll(test.dialects).fixpoint(test)
+    for s in test.callable_region.blocks[0].stmts:
+        if not isinstance(s, gate.stmts.Gate):
+            assert merge_key(s) is None
+
+
+def test_rotation_with_same_angle_ssa_merges():
+    @squin.kernel
+    def test():
+        q = squin.qalloc(2)
+        angle = 0.25
+        squin.rx(angle, q[0])
+        squin.rx(angle, q[1])
+
+    AggressiveUnroll(test.dialects).fixpoint(test)
+    rule = _build_rule_keyed(test, attr_names_by_type={gate.stmts.Rx: ("angle",)})
+    Walk(rule).rewrite(test.code)
+    rxs = _gate_stmts(test, gate.stmts.Rx)
+    assert len(rxs) == 1
+    qubits_stmt = rxs[0].qubits.owner
+    assert isinstance(qubits_stmt, ilist.New)
+    assert len(qubits_stmt.values) == 2
+
+
+def test_rotation_with_distinct_angle_values_does_not_merge():
+    """Different angle values produce distinct SSA values → distinct keys → no merge.
+
+    Note: identical literal values get deduplicated by CSE inside AggressiveUnroll,
+    so distinct-but-equal-literal angles WOULD merge. Use truly different values to
+    exercise the negative path."""
+
+    @squin.kernel
+    def test():
+        q = squin.qalloc(2)
+        squin.rx(0.25, q[0])
+        squin.rx(0.5, q[1])
+
+    AggressiveUnroll(test.dialects).fixpoint(test)
+    rule = _build_rule_keyed(test, attr_names_by_type={gate.stmts.Rx: ("angle",)})
+    Walk(rule).rewrite(test.code)
+    rxs = _gate_stmts(test, gate.stmts.Rx)
+    assert len(rxs) == 2
+
+
+def test_two_disjoint_cz_pairs_merge():
+    @squin.kernel
+    def test():
+        q = squin.qalloc(4)
+        squin.cz(q[0], q[1])
+        squin.cz(q[2], q[3])
+
+    AggressiveUnroll(test.dialects).fixpoint(test)
+    rule = _build_rule_simple(test)
+    Walk(rule).rewrite(test.code)
+
+    czs = _gate_stmts(test, gate.stmts.CZ)
+    assert len(czs) == 1
+    ctrls_owner = czs[0].controls.owner
+    targets_owner = czs[0].targets.owner
+    assert isinstance(ctrls_owner, ilist.New)
+    assert isinstance(targets_owner, ilist.New)
+    assert len(ctrls_owner.values) == 2
+    assert len(targets_owner.values) == 2
+
+
+def test_phased_xz_with_matching_exponents_merges():
+    @squin.kernel
+    def test():
+        q = squin.qalloc(2)
+        x_exp = 0.5
+        z_exp = 0.25
+        ax_exp = 0.125
+        squin.phased_xz(x_exp, z_exp, ax_exp, q[0])
+        squin.phased_xz(x_exp, z_exp, ax_exp, q[1])
+
+    AggressiveUnroll(test.dialects).fixpoint(test)
+    rule = _build_rule_keyed(
+        test,
+        attr_names_by_type={
+            gate.stmts.PhasedXZ: (
+                "x_exponent",
+                "z_exponent",
+                "axis_phase_exponent",
+            )
+        },
+    )
+    Walk(rule).rewrite(test.code)
+
+    pxz = _gate_stmts(test, gate.stmts.PhasedXZ)
+    assert len(pxz) == 1
+    assert isinstance(pxz[0].qubits.owner, ilist.New)
+    assert len(pxz[0].qubits.owner.values) == 2
+
+
+def _pierce(ids, inc, out, key, fixed=None, top=None):
+    return pierce_into_fixed(ids, inc, out, key, fixed or {}, top or (len(ids) + 1))
+
+
+def test_pierce_chain_strictly_increasing():
+    # 0 -> 1 -> 2 dependency chain
+    ids = [0, 1, 2]
+    inc = {0: set(), 1: {0}, 2: {1}}
+    out = {0: {1}, 1: {2}, 2: set()}
+    key = {0: ("X",), 1: ("X",), 2: ("X",)}
+    lv = _pierce(ids, inc, out, key)
+    assert lv[0] < lv[1] < lv[2]
+
+
+def test_pierce_independent_same_key_share_level():
+    ids = [0, 1]
+    inc = {0: set(), 1: set()}
+    out = {0: set(), 1: set()}
+    key = {0: ("X",), 1: ("X",)}
+    lv = _pierce(ids, inc, out, key)
+    assert lv[0] == lv[1]
+
+
+def test_pierce_two_neighbouring_x_layers_merge():
+    # 0 (X) independent; 1 (X) feeding a later Y (node 2). The two X still share
+    # a level — the Y below doesn't pin them apart.
+    ids = [0, 1, 2]
+    inc = {0: set(), 1: set(), 2: {1}}
+    out = {0: set(), 1: {2}, 2: set()}
+    key = {0: ("X",), 1: ("X",), 2: ("Y",)}
+    lv = _pierce(ids, inc, out, key)
+    assert lv[0] == lv[1]
+
+
+def test_pierce_fixed_wall_separates_gates():
+    # 0 (X) -> wall W (fixed CZ) -> 1 (X). W is between them, so they cannot
+    # share a level: 0 below the wall, 1 above.
+    ids = [0, "W", 1]
+    inc = {0: set(), "W": {0}, 1: {"W"}}
+    out = {0: {"W"}, "W": {1}, 1: set()}
+    key = {0: ("X",), "W": ("CZ",), 1: ("X",)}
+    lv = pierce_into_fixed(ids, inc, out, key, {"W": 5}, top=10)
+    assert lv["W"] == 5  # wall stays put
+    assert lv[0] < 5 < lv[1]
+
+
+def test_pierce_merges_past_idle_wall():
+    # 0 (X) and 1 (X) independent; a fixed wall W that touches neither (their
+    # qubits are idle there). They merge despite the wall existing.
+    ids = [0, 1, "W"]
+    inc = {0: set(), 1: set(), "W": set()}
+    out = {0: set(), 1: set(), "W": set()}
+    key = {0: ("X",), 1: ("X",), "W": ("CZ",)}
+    lv = pierce_into_fixed(ids, inc, out, key, {"W": 5}, top=10)
+    assert lv[0] == lv[1]


### PR DESCRIPTION
## What this adds

`LayerOptimize` — a squin pass that reduces the number of **single-qubit pulse layers** in a Clifford circuit while keeping the 2-qubit (CZ) layers fixed. The unitary is preserved.

```python
from bloqade.squin.passes import LayerOptimize

LayerOptimize(mt.dialects)(mt)   # rewrites the circuit in place
```

## How it works

1. Normalize the circuit to `{√X, √Y, S, CZ}` + trailing Paulis.
2. Search over per-qubit "frames" (swap √X↔√Y via S-conjugation) to make each layer more uniform.
3. Cancel/merge the diagonal `S` gates that commute through the CZ layers.
4. Batch same-type single-qubit gates on disjoint qubits into one broadcast pulse.

A no-regression guard ensures the result is never worse than the input.

## Results

~18% fewer single-qubit layers on average (up to ~33%) on random Clifford circuits, unitary-preserved. The frame search uses a fast layer-count estimate (no IR per candidate), so it scales.

## Tests

- Unitary equivalence (cirq/stim) on random circuits
- Layer-count benchmark gate (no regression + net improvement)
- Cold-import guard for the `squin.passes` import graph

🤖 Generated with [Claude Code](https://claude.com/claude-code)