### PR TITLE
feat: emit if-statement from squin kernel as cirq classical control

### DIFF
--- a/src/bloqade/analysis/validation/cirq_classical_control.py
+++ b/src/bloqade/analysis/validation/cirq_classical_control.py
@@ -1,0 +1,37 @@
+from kirin.validation import ValidationPass
+from bloqade.squin import stmts, expr
+
+class CirqClassicalControlValidation(ValidationPass):
+    """Validates that a SQuIN IfStmt can be emitted as a Cirq classical control."""
+    
+    def visit_IfStmt(self, node: stmts.IfStmt):
+        # Criteria 1: Must be a direct boolean comparison against 1/0/True/False
+        valid_condition = False
+        if hasattr(node, 'condition') and hasattr(node.condition, 'op'):
+            lhs = getattr(node.condition, 'lhs', None)
+            rhs = getattr(node.condition, 'rhs', None)
+            
+            def is_valid_literal(n):
+                return isinstance(n, expr.Constant) and n.value in (0, 1, True, False)
+                
+            def is_valid_measure_ref(n):
+                return isinstance(n, expr.Var)
+            
+            if (is_valid_measure_ref(lhs) and is_valid_literal(rhs)) or \
+               (is_valid_measure_ref(rhs) and is_valid_literal(lhs)):
+                valid_condition = True
+                
+        if not valid_condition:
+            self.error(node, "If statement condition must be a direct equality comparison against a single measurement using True/False or 1/0.")
+            
+        # Criteria 2: The else body must be empty
+        if hasattr(node, 'else_body') and node.else_body is not None:
+            if hasattr(node.else_body, 'stmts') and len(node.else_body.stmts) > 0:
+                self.error(node, "Cirq classical control requires the 'else' body to be empty.")
+                
+        # Criteria 3: The then body must contain exactly one gate operation
+        body_stmts = node.body.stmts if hasattr(node.body, 'stmts') else node.body
+        if len(body_stmts) != 1 or not isinstance(body_stmts[0], (stmts.GateStmt, stmts.ApplyGate)):
+            self.error(node, "Cirq classical control requires the 'then' body to contain exactly one gate operation.")
+
+        self.generic_visit(node)

--- a/src/bloqade/cirq_utils/emit/base.py
+++ b/src/bloqade/cirq_utils/emit/base.py
@@ -9,6 +9,10 @@ from kirin.interp import MethodTable, impl
 from kirin.dialects import py, func, ilist
 from typing_extensions import Self
 
+import sympy
+from bloqade.analysis.validation.cirq_classical_control import CirqClassicalControlValidation
+from bloqade.squin import stmts, expr
+
 from bloqade.squin import kernel
 from bloqade.rewrite.passes import AggressiveUnroll
 
@@ -156,6 +160,11 @@ def emit_circuit(
     )
 
     AggressiveUnroll(mt_.dialects).fixpoint(mt_)
+
+    # Run the classical control validation pass
+    validator = CirqClassicalControlValidation()
+    validator.run(mt_)
+
     emitter.initialize()
     emitter.run(mt_)
     return emitter.circuit
@@ -244,3 +253,44 @@ class __IList(interp.MethodTable):
         stmt: ilist.New,
     ):
         return (ilist.IList(data=frame.get_values(stmt.values)),)
+
+
+@stmts.dialect.register(key="emit.cirq")
+class __StmtsEmit(interp.MethodTable):
+
+    @interp.impl(stmts.IfStmt)
+    def emit_if_stmt(self, emit: EmitCirq, frame: EmitCirqFrame, stmt: stmts.IfStmt):
+        # Extract condition nodes from the expression structure
+        lhs = stmt.condition.lhs
+        rhs = stmt.condition.rhs
+        
+        var_node = lhs if isinstance(lhs, expr.Var) else rhs
+        lit_node = rhs if isinstance(lhs, expr.Var) else lhs
+        trigger_val = lit_node.value
+        
+        meas_key = str(var_node.name)
+        
+        # Unpack the single gate statement inside the conditional block
+        body_stmts = stmt.body.stmts if hasattr(stmt.body, 'stmts') else stmt.body
+        gate_stmt = body_stmts[0]
+        
+        # Isolate the circuit generation to capture the underlying gate operations safely
+        original_circuit = emit.circuit
+        emit.circuit = cirq.Circuit()
+        
+        # Evaluate the inner gate statement within the temporary circuit context
+        emit.frame_eval(frame, gate_stmt)
+        sub_circuit = emit.circuit
+        
+        # Restore the main circuit pipeline
+        emit.circuit = original_circuit
+        
+        # Construct the conditional symbol condition for Cirq feed-forward tracking
+        condition_expr = sympy.Symbol(meas_key) == trigger_val
+        
+        # Wrap all inner operations with classical controls and append them to the main circuit
+        for op in sub_circuit.all_operations():
+            controlled_op = op.with_classical_controls(condition_expr)
+            emit.circuit.append(controlled_op)
+            
+        return ()


### PR DESCRIPTION
Closes #408

**Description:**
This PR enables the emission of SQuIN `IfStmt` kernels into `cirq` classical controls, ensuring compatibility with hardware-efficient execution logic.

**Implementation Details:**
1. Added `CirqClassicalControlValidation` to `src/bloqade/analysis/validation/` to ensure the `if` statement relies on a direct equality comparison against a single measurement, has an empty `else` body, and contains exactly one gate operation.
2. Integrated the validation pass directly into `emit_circuit` immediately after the aggressive unroll phase.
3. Added a new `@stmts.dialect.register` dispatcher for `stmts.IfStmt` that extracts the measurement key, evaluates the underlying gate using an isolated temporary circuit state to prevent side effects, and wraps the operations using `cirq_operation.with_classical_controls(sympy.Symbol(meas_key) == trigger_val)`.