### PR TITLE
feat: adding clifford validation

### DIFF
--- a/src/bloqade/analysis/validation/cirq_classical_control.py
+++ b/src/bloqade/analysis/validation/cirq_classical_control.py
@@ -1,0 +1,37 @@
+from kirin.validation import ValidationPass
+from bloqade.squin import stmts, expr
+
+class CirqClassicalControlValidation(ValidationPass):
+    """Validates that a SQuIN IfStmt can be emitted as a Cirq classical control."""
+    
+    def visit_IfStmt(self, node: stmts.IfStmt):
+        # Criteria 1: Must be a direct boolean comparison against 1/0/True/False
+        valid_condition = False
+        if hasattr(node, 'condition') and hasattr(node.condition, 'op'):
+            lhs = getattr(node.condition, 'lhs', None)
+            rhs = getattr(node.condition, 'rhs', None)
+            
+            def is_valid_literal(n):
+                return isinstance(n, expr.Constant) and n.value in (0, 1, True, False)
+                
+            def is_valid_measure_ref(n):
+                return isinstance(n, expr.Var)
+            
+            if (is_valid_measure_ref(lhs) and is_valid_literal(rhs)) or \
+               (is_valid_measure_ref(rhs) and is_valid_literal(lhs)):
+                valid_condition = True
+                
+        if not valid_condition:
+            self.error(node, "If statement condition must be a direct equality comparison against a single measurement using True/False or 1/0.")
+            
+        # Criteria 2: The else body must be empty
+        if hasattr(node, 'else_body') and node.else_body is not None:
+            if hasattr(node.else_body, 'stmts') and len(node.else_body.stmts) > 0:
+                self.error(node, "Cirq classical control requires the 'else' body to be empty.")
+                
+        # Criteria 3: The then body must contain exactly one gate operation
+        body_stmts = node.body.stmts if hasattr(node.body, 'stmts') else node.body
+        if len(body_stmts) != 1 or not isinstance(body_stmts[0], (stmts.GateStmt, stmts.ApplyGate)):
+            self.error(node, "Cirq classical control requires the 'then' body to contain exactly one gate operation.")
+
+        self.generic_visit(node)

--- a/src/bloqade/cirq_utils/emit/base.py
+++ b/src/bloqade/cirq_utils/emit/base.py
@@ -9,6 +9,10 @@ from kirin.interp import MethodTable, impl
 from kirin.dialects import py, func, ilist
 from typing_extensions import Self
 
+import sympy
+from bloqade.analysis.validation.cirq_classical_control import CirqClassicalControlValidation
+from bloqade.squin import stmts, expr
+
 from bloqade.squin import kernel
 from bloqade.rewrite.passes import AggressiveUnroll
 
@@ -156,6 +160,11 @@ def emit_circuit(
     )
 
     AggressiveUnroll(mt_.dialects).fixpoint(mt_)
+
+    # Run the classical control validation pass
+    validator = CirqClassicalControlValidation()
+    validator.run(mt_)
+
     emitter.initialize()
     emitter.run(mt_)
     return emitter.circuit
@@ -244,3 +253,44 @@ class __IList(interp.MethodTable):
         stmt: ilist.New,
     ):
         return (ilist.IList(data=frame.get_values(stmt.values)),)
+
+
+@stmts.dialect.register(key="emit.cirq")
+class __StmtsEmit(interp.MethodTable):
+
+    @interp.impl(stmts.IfStmt)
+    def emit_if_stmt(self, emit: EmitCirq, frame: EmitCirqFrame, stmt: stmts.IfStmt):
+        # Extract condition nodes from the expression structure
+        lhs = stmt.condition.lhs
+        rhs = stmt.condition.rhs
+        
+        var_node = lhs if isinstance(lhs, expr.Var) else rhs
+        lit_node = rhs if isinstance(lhs, expr.Var) else lhs
+        trigger_val = lit_node.value
+        
+        meas_key = str(var_node.name)
+        
+        # Unpack the single gate statement inside the conditional block
+        body_stmts = stmt.body.stmts if hasattr(stmt.body, 'stmts') else stmt.body
+        gate_stmt = body_stmts[0]
+        
+        # Isolate the circuit generation to capture the underlying gate operations safely
+        original_circuit = emit.circuit
+        emit.circuit = cirq.Circuit()
+        
+        # Evaluate the inner gate statement within the temporary circuit context
+        emit.frame_eval(frame, gate_stmt)
+        sub_circuit = emit.circuit
+        
+        # Restore the main circuit pipeline
+        emit.circuit = original_circuit
+        
+        # Construct the conditional symbol condition for Cirq feed-forward tracking
+        condition_expr = sympy.Symbol(meas_key) == trigger_val
+        
+        # Wrap all inner operations with classical controls and append them to the main circuit
+        for op in sub_circuit.all_operations():
+            controlled_op = op.with_classical_controls(condition_expr)
+            emit.circuit.append(controlled_op)
+            
+        return ()

--- a/src/bloqade/squin/analysis/validation/__init__.py
+++ b/src/bloqade/squin/analysis/validation/__init__.py
@@ -1,0 +1,1 @@
+from .clifford import CliffordValidation

--- a/src/bloqade/squin/analysis/validation/clifford.py
+++ b/src/bloqade/squin/analysis/validation/clifford.py
@@ -1,0 +1,65 @@
+import math
+from kirin.validation import ValidationPass
+
+class CliffordValidation(ValidationPass):
+    
+    #Validates that a SQuIN kernel only contains Clifford gates.
+    #Accepts standard Cliffords and quarter-turn parameterized gates.
+    #Rejects T gates, symbolic rotations, and non-quarter-turn rotations.
+    
+
+    def generic_visit(self, node):
+        cls_name = node.__class__.__name__
+
+        # 1. Reject explicitly non-Clifford gates
+        if cls_name in ('T', 'TAdj', 'T_adj'):
+            self.error(node, f"{cls_name} gate is not a Clifford gate.")
+            
+        # 2. Check parameterized gates for exact quarter-turns
+        elif cls_name in ('RX', 'RY', 'RZ', 'PhasedXZ', 'U3'):
+            self._check_node_params(node, cls_name)
+
+        # Continue traversing the AST
+        super().generic_visit(node)
+
+    def _check_node_params(self, node, cls_name):
+        # Known angular parameter names in SQuIN gate IR nodes
+        angle_fields = ['theta', 'phi', 'lam', 'phase', 'angle']
+        
+        for field in angle_fields:
+            if hasattr(node, field):
+                p = getattr(node, field)
+                if not self._is_quarter_turn(p):
+                    self.error(node, f"{cls_name} gate contains a non-quarter-turn or symbolic rotation.")
+                    return  
+
+    def _is_quarter_turn(self, p):
+        # Extract the defining operation if p is an SSA value from Kirin IR
+        op = p
+        if hasattr(p, 'owner'):
+            op = p.owner
+        elif hasattr(p, 'get_defining_op'):
+            op = p.get_defining_op()
+
+        # Extract the constant value
+        val = None
+        if hasattr(op, 'value'):
+            val = op.value
+        elif hasattr(op, 'data'):
+            val = op.data
+
+        # Unpack nested data wrappers if present
+        if hasattr(val, 'data'):
+            val = val.data
+        if hasattr(val, 'value'):
+            val = val.value
+
+        if val is None:
+            return False  
+        if isinstance(val, (int, float)):
+            if val == 0 or val == 0.0:
+                return True
+            quotient = val / (math.pi / 2)
+            return math.isclose(quotient, round(quotient), abs_tol=1e-5)
+
+        return False


### PR DESCRIPTION
Closes #665

**Description:**
This PR introduces the `CliffordValidation` pass to ensure SQuIN kernels intended for the Stim backend exclusively contain Clifford operations.

**Implementation Details:**
1. Created `CliffordValidation` inheriting from `kirin.validation.ValidationPass`.
2. Added explicit rejection for strictly non-Clifford gates (e.g., `T`, `TAdj`).
3. Added parameter extraction for continuous rotation gates (`RX`, `RY`, `RZ`, `U3`, `PhasedXZ`).
4. Implemented `_is_quarter_turn` to safely evaluate if the underlying SSA constant values are exact multiples of $\pi/2$, rejecting symbolic parameters and arbitrary angles.