### PR TITLE
Add opt-in TICK insertion to Squin → Stim lowering (#816)

### DIFF
--- a/src/bloqade/stim/circuit.py
+++ b/src/bloqade/stim/circuit.py
@@ -22,10 +22,18 @@ except ImportError:
     _Circuit = _MissingStimCircuit
 
 
-def _codegen(mt: ir.Method) -> str:
-    """Compile a kernel to STIM program string."""
+def _codegen(mt: ir.Method, insert_ticks: bool = False) -> str:
+    """Compile a kernel to STIM program string.
+
+    Args:
+        mt: The kernel to compile.
+        insert_ticks: If True, insert a ``TICK`` after every gate, reset,
+            measurement, and noise operation so the emitted circuit preserves
+            the authored execution-order layering when rendered as a diagram.
+            Timing-only, so record/detector indexing is unaffected.
+    """
     mt = mt.similar()
-    SquinToStimPass(mt.dialects)(mt)
+    SquinToStimPass(mt.dialects, insert_ticks=insert_ticks)(mt)
     buf = io.StringIO()
     emit = EmitStimMain(dialects=bloqade_stim.main, io=buf)
     emit.initialize()
@@ -36,7 +44,9 @@ def _codegen(mt: ir.Method) -> str:
 class Circuit(_Circuit):
     """A `stim.Circuit` that can be built from a squin kernel or a program string."""
 
-    def __init__(self, kernel: ir.Method | str, *args, **kwargs):
+    def __init__(
+        self, kernel: ir.Method | str, *args, insert_ticks: bool = False, **kwargs
+    ):
         """Initialize stim.Circuit from a kernel or a STIM program string.
 
         This class inherits from `stim.Circuit`. For the full API reference of
@@ -47,9 +57,13 @@ class Circuit(_Circuit):
             kernel: The kernel to compile into a stim.Circuit, or a STIM program
                 string to pass directly to the underlying circuit.
             *args: Additional positional arguments forwarded to `stim.Circuit`.
+            insert_ticks: When compiling a kernel, insert a ``TICK`` after every
+                gate, reset, measurement, and noise operation so the diagram
+                preserves the authored execution-order layering. Ignored when
+                ``kernel`` is a program string.
             **kwargs: Additional keyword arguments forwarded to `stim.Circuit`.
 
         """
         if isinstance(kernel, ir.Method):
-            kernel = _codegen(kernel)
+            kernel = _codegen(kernel, insert_ticks=insert_ticks)
         super().__init__(kernel, *args, **kwargs)

--- a/src/bloqade/stim/passes/squin_to_stim.py
+++ b/src/bloqade/stim/passes/squin_to_stim.py
@@ -157,7 +157,7 @@ class SquinToStimPass(Pass):
             .join(rewrite_result)
         )
 
-        # --- optional TICK insertion (after cleanup so DCE leaves them alone) ---
+        # --- optional TICK insertion (after all other rewrites) ---
         if self.insert_ticks:
             rewrite_result = (
                 Walk(InsertTicks()).rewrite(mt.code).join(rewrite_result)

--- a/src/bloqade/stim/passes/squin_to_stim.py
+++ b/src/bloqade/stim/passes/squin_to_stim.py
@@ -14,6 +14,7 @@ from kirin.ir.exception import ValidationErrorGroup
 
 from bloqade.stim.groups import main as stim_main
 from bloqade.stim.rewrite import (
+    InsertTicks,
     ScfForToRepeat,
     IfToStimPartial,
     SquinGateToStim,
@@ -41,6 +42,14 @@ from bloqade.stim.analysis.from_squin_validation import StimFromSquinValidation
 
 @dataclass
 class SquinToStimPass(Pass):
+
+    insert_ticks: bool = False
+    """Insert a ``TICK`` after every gate, reset, measurement, and noise
+    operation so the emitted Stim circuit preserves the authored execution-order
+    layering (one moment per step) instead of being ASAP-packed when rendered as
+    a diagram. ``TICK`` is a timing-only annotation, so enabling this does not
+    change measurement-record or detector/observable indexing. Default off to
+    keep existing Stim output unchanged."""
 
     def unsafe_run(self, mt: Method) -> RewriteResult:
 
@@ -147,5 +156,11 @@ class SquinToStimPass(Pass):
             .rewrite(mt.code)
             .join(rewrite_result)
         )
+
+        # --- optional TICK insertion (after cleanup so DCE leaves them alone) ---
+        if self.insert_ticks:
+            rewrite_result = (
+                Walk(InsertTicks()).rewrite(mt.code).join(rewrite_result)
+            )
 
         return rewrite_result

--- a/src/bloqade/stim/passes/squin_to_stim.py
+++ b/src/bloqade/stim/passes/squin_to_stim.py
@@ -42,6 +42,7 @@ from bloqade.stim.analysis.from_squin_validation import StimFromSquinValidation
 
 @dataclass
 class SquinToStimPass(Pass):
+    """Lower a squin kernel into the STIM dialect."""
 
     insert_ticks: bool = False
     """Insert a ``TICK`` after every gate, reset, measurement, and noise
@@ -52,7 +53,7 @@ class SquinToStimPass(Pass):
     keep existing Stim output unchanged."""
 
     def unsafe_run(self, mt: Method) -> RewriteResult:
-
+        """Run the squin-to-stim lowering rewrites in place on ``mt``."""
         rewrite_result = Flatten(dialects=mt.dialects, no_raise=self.no_raise).fixpoint(
             mt
         )
@@ -159,8 +160,6 @@ class SquinToStimPass(Pass):
 
         # --- optional TICK insertion (after all other rewrites) ---
         if self.insert_ticks:
-            rewrite_result = (
-                Walk(InsertTicks()).rewrite(mt.code).join(rewrite_result)
-            )
+            rewrite_result = Walk(InsertTicks()).rewrite(mt.code).join(rewrite_result)
 
         return rewrite_result

--- a/src/bloqade/stim/rewrite/__init__.py
+++ b/src/bloqade/stim/rewrite/__init__.py
@@ -1,3 +1,4 @@
+from .insert_ticks import InsertTicks as InsertTicks
 from .squin_noise import SquinNoiseToStim as SquinNoiseToStim
 from .qubit_to_stim import (
     SquinGateToStim as SquinGateToStim,

--- a/src/bloqade/stim/rewrite/__init__.py
+++ b/src/bloqade/stim/rewrite/__init__.py
@@ -1,5 +1,7 @@
-from .insert_ticks import InsertTicks as InsertTicks
+"""Rewrite rules for lowering the squin dialect into the STIM dialect."""
+
 from .squin_noise import SquinNoiseToStim as SquinNoiseToStim
+from .insert_ticks import InsertTicks as InsertTicks
 from .qubit_to_stim import (
     SquinGateToStim as SquinGateToStim,
     SquinResetToStim as SquinResetToStim,

--- a/src/bloqade/stim/rewrite/insert_ticks.py
+++ b/src/bloqade/stim/rewrite/insert_ticks.py
@@ -26,9 +26,11 @@ class InsertTicks(RewriteRule):
 
     @staticmethod
     def is_operation(stmt: ir.Statement) -> bool:
+        """Whether the statement is a moment-advancing Stim operation."""
         return getattr(stmt, "dialect", None) in OPERATION_DIALECTS
 
     def rewrite_Statement(self, node: ir.Statement) -> RewriteResult:
+        """Insert a ``TICK`` after ``node`` when it is an un-ticked operation."""
         if not self.is_operation(node):
             return RewriteResult()
 

--- a/src/bloqade/stim/rewrite/insert_ticks.py
+++ b/src/bloqade/stim/rewrite/insert_ticks.py
@@ -1,0 +1,40 @@
+from kirin import ir
+from kirin.rewrite.abc import RewriteRule, RewriteResult
+
+from bloqade.stim.dialects import auxiliary
+
+# Stim dialects whose statements advance a circuit "moment" / time step. A TICK
+# after every such operation forces Stim to render one moment per step instead
+# of ASAP-packing the diagram. Statements in the auxiliary dialect (constants,
+# records, detectors, observables, coordinate annotations) and control flow do
+# not advance a moment, so they are left untouched -- measurement-record and
+# detector indexing are unaffected.
+OPERATION_DIALECTS = frozenset({"stim.gate", "stim.collapse", "stim.noise"})
+
+
+class InsertTicks(RewriteRule):
+    """Insert a ``TICK`` after every Stim operation.
+
+    Operates on a lowered Stim circuit. After each operation statement (gate,
+    reset, measurement, or noise channel) a
+    :class:`~bloqade.stim.dialects.auxiliary.stmts.Tick` is inserted, so the
+    rendered diagram's columns follow program order rather than ASAP packing.
+
+    The rule is idempotent -- an operation already followed by a ``TICK`` is
+    left untouched -- so it is safe under :class:`~kirin.rewrite.Fixpoint`.
+    """
+
+    @staticmethod
+    def is_operation(stmt: ir.Statement) -> bool:
+        dialect = getattr(stmt, "dialect", None)
+        return dialect is not None and dialect.name in OPERATION_DIALECTS
+
+    def rewrite_Statement(self, node: ir.Statement) -> RewriteResult:
+        if not self.is_operation(node):
+            return RewriteResult()
+
+        if isinstance(node.next_stmt, auxiliary.stmts.Tick):
+            return RewriteResult()
+
+        auxiliary.stmts.Tick().insert_after(node)
+        return RewriteResult(has_done_something=True)

--- a/src/bloqade/stim/rewrite/insert_ticks.py
+++ b/src/bloqade/stim/rewrite/insert_ticks.py
@@ -1,7 +1,7 @@
 from kirin import ir
 from kirin.rewrite.abc import RewriteRule, RewriteResult
 
-from bloqade.stim.dialects import auxiliary
+from bloqade.stim.dialects import gate, noise, collapse, auxiliary
 
 # Stim dialects whose statements advance a circuit "moment" / time step. A TICK
 # after every such operation forces Stim to render one moment per step instead
@@ -9,7 +9,7 @@ from bloqade.stim.dialects import auxiliary
 # records, detectors, observables, coordinate annotations) and control flow do
 # not advance a moment, so they are left untouched -- measurement-record and
 # detector indexing are unaffected.
-OPERATION_DIALECTS = frozenset({"stim.gate", "stim.collapse", "stim.noise"})
+OPERATION_DIALECTS = frozenset({gate.dialect, collapse.dialect, noise.dialect})
 
 
 class InsertTicks(RewriteRule):
@@ -26,8 +26,7 @@ class InsertTicks(RewriteRule):
 
     @staticmethod
     def is_operation(stmt: ir.Statement) -> bool:
-        dialect = getattr(stmt, "dialect", None)
-        return dialect is not None and dialect.name in OPERATION_DIALECTS
+        return getattr(stmt, "dialect", None) in OPERATION_DIALECTS
 
     def rewrite_Statement(self, node: ir.Statement) -> RewriteResult:
         if not self.is_operation(node):

--- a/src/bloqade/stim/upstream/from_squin.py
+++ b/src/bloqade/stim/upstream/from_squin.py
@@ -4,7 +4,7 @@ from ..groups import main
 from ..passes.squin_to_stim import SquinToStimPass
 
 
-def squin_to_stim(mt: ir.Method) -> ir.Method:
+def squin_to_stim(mt: ir.Method, insert_ticks: bool = False) -> ir.Method:
     new_mt = mt.similar()
-    SquinToStimPass(mt.dialects, no_raise=False)(new_mt)
+    SquinToStimPass(mt.dialects, no_raise=False, insert_ticks=insert_ticks)(new_mt)
     return new_mt.similar(dialects=main)

--- a/src/bloqade/stim/upstream/from_squin.py
+++ b/src/bloqade/stim/upstream/from_squin.py
@@ -5,6 +5,18 @@ from ..passes.squin_to_stim import SquinToStimPass
 
 
 def squin_to_stim(mt: ir.Method, insert_ticks: bool = False) -> ir.Method:
+    """Lower a squin kernel to the STIM dialect.
+
+    Args:
+        mt: The squin kernel to lower.
+        insert_ticks: If True, insert a ``TICK`` after every gate, reset,
+            measurement, and noise operation so the emitted circuit preserves
+            the authored execution-order layering when rendered as a diagram.
+            Timing-only, so record/detector indexing is unaffected.
+
+    Returns:
+        A new method lowered to the STIM main dialect group.
+    """
     new_mt = mt.similar()
     SquinToStimPass(mt.dialects, no_raise=False, insert_ticks=insert_ticks)(new_mt)
     return new_mt.similar(dialects=main)

--- a/src/bloqade/tsim/circuit.py
+++ b/src/bloqade/tsim/circuit.py
@@ -21,7 +21,9 @@ except ImportError:
 class Circuit(_Circuit):
     """A `tsim.Circuit` that can be built from a squin kernel or a program string."""
 
-    def __init__(self, kernel: ir.Method | str, *args, **kwargs):
+    def __init__(
+        self, kernel: ir.Method | str, *args, insert_ticks: bool = False, **kwargs
+    ):
         """Initialize tsim.Circuit from a kernel or a STIM program string.
 
         This class inherits from `tsim.Circuit`. For the full API reference of
@@ -32,9 +34,13 @@ class Circuit(_Circuit):
             kernel: The kernel to compile into a tsim.Circuit, or a STIM program
                 string to pass directly to the underlying circuit.
             *args: Additional positional arguments forwarded to `tsim.Circuit`.
+            insert_ticks: When compiling a kernel, insert a ``TICK`` after every
+                gate, reset, measurement, and noise operation so the diagram
+                preserves the authored execution-order layering. Ignored when
+                ``kernel`` is a program string.
             **kwargs: Additional keyword arguments forwarded to `tsim.Circuit`.
 
         """
         if isinstance(kernel, ir.Method):
-            kernel = _codegen(kernel)
+            kernel = _codegen(kernel, insert_ticks=insert_ticks)
         super().__init__(kernel, *args, **kwargs)

--- a/test/stim/passes/test_insert_ticks.py
+++ b/test/stim/passes/test_insert_ticks.py
@@ -1,0 +1,122 @@
+import io
+
+from kirin import ir
+from kirin.rewrite import Walk
+
+from bloqade import stim, squin
+from bloqade.stim.emit import EmitStimMain
+from bloqade.stim.rewrite import InsertTicks
+from bloqade.stim.passes import SquinToStimPass
+
+
+def codegen(mt: ir.Method):
+    buf = io.StringIO()
+    emit = EmitStimMain(dialects=stim.main, io=buf)
+    emit.initialize()
+    emit.run(mt)
+    return buf.getvalue().strip()
+
+
+def _linear_kernel():
+    @squin.kernel
+    def test():
+        ql = squin.qalloc(3)
+        squin.broadcast.h(ql)
+        squin.x(ql[0])
+        squin.cx(ql[0], ql[1])
+        squin.broadcast.measure(ql)
+        return
+
+    return test
+
+
+def test_default_has_no_ticks():
+    test = _linear_kernel()
+    SquinToStimPass(test.dialects)(test)
+    out = codegen(test)
+    assert "TICK" not in out
+    assert out == "\n".join(
+        [
+            "H 0 1 2",
+            "X 0",
+            "CX 0 1",
+            "MZ(0.00000000) 0 1 2",
+        ]
+    )
+
+
+def test_insert_ticks_separates_operations():
+    test = _linear_kernel()
+    SquinToStimPass(test.dialects, insert_ticks=True)(test)
+    out = codegen(test)
+    assert out == "\n".join(
+        [
+            "H 0 1 2",
+            "TICK",
+            "X 0",
+            "TICK",
+            "CX 0 1",
+            "TICK",
+            "MZ(0.00000000) 0 1 2",
+            "TICK",
+        ]
+    )
+
+
+def test_insert_ticks_preserves_record_indices():
+    """TICKs are timing-only: detector/observable record indices must match
+    the no-tick lowering exactly."""
+
+    def make():
+        @squin.kernel
+        def main():
+            q = squin.qalloc(4)
+            squin.x(q[0])
+            squin.cx(q[0], q[1])
+            ms = squin.broadcast.measure(q)
+            squin.set_detector([ms[0], ms[1]], coordinates=[0.0, 0.0])
+            squin.set_observable(measurements=[ms[2]])
+            return
+
+        return main
+
+    no_ticks = make()
+    SquinToStimPass(no_ticks.dialects)(no_ticks)
+
+    with_ticks = make()
+    SquinToStimPass(with_ticks.dialects, insert_ticks=True)(with_ticks)
+
+    def record_lines(out):
+        return [
+            line
+            for line in out.splitlines()
+            if line.startswith(("DETECTOR", "OBSERVABLE_INCLUDE"))
+        ]
+
+    assert record_lines(codegen(no_ticks)) == record_lines(codegen(with_ticks))
+
+
+def test_insert_ticks_inside_repeat_block():
+    @squin.kernel
+    def test():
+        qs = squin.qalloc(3)
+        squin.broadcast.reset(qs)
+        for _ in range(5):
+            squin.broadcast.h(qs)
+            squin.cz(control=qs[0], target=qs[1])
+
+    SquinToStimPass(test.dialects, insert_ticks=True)(test)
+    out = codegen(test)
+    assert "REPEAT 5 {" in out
+    # both operations inside the loop body are tick-separated
+    body = out[out.index("{") : out.index("}")]
+    assert body.count("TICK") == 2
+
+
+def test_insert_ticks_rewrite_is_idempotent():
+    test = _linear_kernel()
+    SquinToStimPass(test.dialects, insert_ticks=True)(test)
+    once = codegen(test)
+    # running the standalone rewrite again must not add duplicate TICKs
+    Walk(InsertTicks()).rewrite(test.code)
+    assert codegen(test) == once

--- a/test/stim/passes/test_insert_ticks.py
+++ b/test/stim/passes/test_insert_ticks.py
@@ -5,11 +5,12 @@ from kirin.rewrite import Walk
 
 from bloqade import stim, squin
 from bloqade.stim.emit import EmitStimMain
-from bloqade.stim.rewrite import InsertTicks
 from bloqade.stim.passes import SquinToStimPass
+from bloqade.stim.rewrite import InsertTicks
 
 
 def codegen(mt: ir.Method):
+    """Emit the lowered method as a STIM program string."""
     buf = io.StringIO()
     emit = EmitStimMain(dialects=stim.main, io=buf)
     emit.initialize()
@@ -18,6 +19,8 @@ def codegen(mt: ir.Method):
 
 
 def _linear_kernel():
+    """Build a simple linear kernel: H, X, CX, then a broadcast measure."""
+
     @squin.kernel
     def test():
         ql = squin.qalloc(3)
@@ -31,6 +34,7 @@ def _linear_kernel():
 
 
 def test_default_has_no_ticks():
+    """Default lowering (insert_ticks=False) emits no TICKs."""
     test = _linear_kernel()
     SquinToStimPass(test.dialects)(test)
     out = codegen(test)
@@ -46,6 +50,7 @@ def test_default_has_no_ticks():
 
 
 def test_insert_ticks_separates_operations():
+    """insert_ticks=True puts a TICK after each operation."""
     test = _linear_kernel()
     SquinToStimPass(test.dialects, insert_ticks=True)(test)
     out = codegen(test)
@@ -97,6 +102,8 @@ def test_insert_ticks_preserves_record_indices():
 
 
 def test_insert_ticks_inside_repeat_block():
+    """TICKs are inserted inside REPEAT loop bodies too."""
+
     @squin.kernel
     def test():
         qs = squin.qalloc(3)
@@ -114,6 +121,7 @@ def test_insert_ticks_inside_repeat_block():
 
 
 def test_insert_ticks_rewrite_is_idempotent():
+    """Re-running the standalone rewrite adds no duplicate TICKs."""
     test = _linear_kernel()
     SquinToStimPass(test.dialects, insert_ticks=True)(test)
     once = codegen(test)

--- a/test/stim/test_circuit.py
+++ b/test/stim/test_circuit.py
@@ -18,6 +18,20 @@ def test_circuit():
     assert str(circuit) == "H 0\nCX 0 1"
 
 
+def test_circuit_insert_ticks():
+    """insert_ticks=True separates operations with TICKs in the lowered circuit."""
+
+    @kernel
+    def main():
+        q = squin.qalloc(2)
+        squin.h(q[0])
+        squin.cx(q[0], q[1])
+
+    circuit = Circuit(main, insert_ticks=True)
+    assert isinstance(circuit, stim.Circuit)
+    assert str(circuit) == "H 0\nTICK\nCX 0 1\nTICK"
+
+
 def test_circuit_from_string():
     """Build a stim.Circuit directly from a STIM program string."""
     program_text = "H 0\nCX 0 1"

--- a/test/tsim/test_circuit.py
+++ b/test/tsim/test_circuit.py
@@ -19,6 +19,20 @@ def test_circuit():
     assert str(circuit) == "H 0\nT 0\nCX 0 1"
 
 
+def test_circuit_insert_ticks():
+    """insert_ticks=True separates operations with TICKs in the lowered circuit."""
+
+    @kernel
+    def main():
+        q = squin.qalloc(2)
+        squin.h(q[0])
+        squin.cx(q[0], q[1])
+
+    circuit = Circuit(main, insert_ticks=True)
+    assert isinstance(circuit, tsim.Circuit)
+    assert str(circuit) == "H 0\nTICK\nCX 0 1\nTICK"
+
+
 def test_circuit_from_string():
     """Build a tsim.Circuit directly from a STIM program string."""
     program_text = "H 0\nT 0\nCX 0 1"


### PR DESCRIPTION
Closes #816.

## What

Adds an opt-in `insert_ticks` flag to the Squin → Stim lowering that inserts a `TICK` after every gate, reset, measurement, and noise operation, so the emitted Stim circuit preserves the **authored execution-order layering** (one moment per step) instead of being ASAP-packed when rendered as a diagram. Default **off**, so existing output is unchanged.

This came up downstream in bloqade-lanes#641, where broadcasting Steane state-prep across logical qubits still rendered in ASAP order with misaligned layers.

## How

- New standalone, idempotent `InsertTicks` rewrite (`bloqade/stim/rewrite/insert_ticks.py`). It's an atomic per-statement rule driven by `Walk`; an "operation" is any statement in the `stim.gate` / `stim.collapse` / `stim.noise` dialects. Auxiliary statements (constants, records, detectors, observables, coordinates) are skipped, and since constants fold into the operation's text at emit time they never produce stray lines.
- `insert_ticks: bool = False` flag on `SquinToStimPass` (runs the rewrite after the cleanup fixpoint, so DCE leaves the no-op `TICK`s alone) and on the `squin_to_stim` entry point.
- Exposed as a keyword-only arg on both `bloqade.tsim.Circuit` and `bloqade.stim.Circuit` (threaded through shared `_codegen`), so a TICK-layered diagram can be requested when building a circuit straight from a squin kernel. Ignored when building from a program string.
- Drive-by: fixed a copy-paste typo in `stim.Circuit`'s docstring (`*args`/`**kwargs` said "forwarded to `tsim.Circuit`").

## Acceptance criteria

- [x] Opt-in flag enables automatic `TICK` insertion in the Squin → Stim lowering.
- [x] With the flag on, emitted circuit has `TICK`s separating operations so diagram columns follow program order.
- [x] Default behavior (flag off) unchanged; existing tests pass.
- [x] Detector/observable/measurement record indices are unaffected by the inserted `TICK`s (verified: identical `rec[...]` indices with and without the flag).

## Notes / decisions

- **Granularity:** per *operation* (not per authored "layer"). Per @weinbe58, operations that would share a parallel layer can't actually run in parallel here, so per-operation is the right unit.
- **Trailing TICK:** the simple per-statement rule emits a `TICK` after the final operation too. Benign/valid Stim; left as-is for now (suppressing it cleanly is a bit tricky and not worth it yet).

## Tests

- `test/stim/passes/test_insert_ticks.py` — default-unchanged, per-operation separation, record-index preservation, ticks inside `REPEAT`, rewrite idempotency.
- `insert_ticks` cases added to `test/stim/test_circuit.py` and `test/tsim/test_circuit.py`.
- Full `test/stim/` + `test/tsim/` suites: 256 passed, 2 xfailed, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)