### PR TITLE
Ignore annotations for Cirq and PyQrack backends

### DIFF
--- a/src/bloqade/cirq_utils/emit/__init__.py
+++ b/src/bloqade/cirq_utils/emit/__init__.py
@@ -5,5 +5,11 @@ Imports dialect emit modules to register method tables and exposes
 """
 
 # NOTE: just to register methods
-from . import scf as scf, gate as gate, noise as noise, qubit as qubit
+from . import (
+    scf as scf,
+    gate as gate,
+    noise as noise,
+    qubit as qubit,
+    annotate as annotate,
+)
 from .base import emit_circuit as emit_circuit

--- a/src/bloqade/cirq_utils/emit/annotate.py
+++ b/src/bloqade/cirq_utils/emit/annotate.py
@@ -1,0 +1,18 @@
+from kirin.interp import MethodTable, impl
+
+from bloqade.decoders.dialects import annotate
+
+from .base import EmitCirq, EmitCirqFrame
+
+
+@annotate.dialect.register(key="emit.cirq")
+class EmitCirqAnnotateMethods(MethodTable):
+    @impl(annotate.stmts.SetDetector)
+    @impl(annotate.stmts.SetObservable)
+    def ignore_annotation(
+        self,
+        emit: EmitCirq,
+        frame: EmitCirqFrame,
+        stmt: annotate.stmts.SetDetector | annotate.stmts.SetObservable,
+    ):
+        return tuple(None for _ in stmt.results)

--- a/src/bloqade/pyqrack/__init__.py
+++ b/src/bloqade/pyqrack/__init__.py
@@ -15,7 +15,7 @@ from .task import PyQrackSimulatorTask as PyQrackSimulatorTask
 # NOTE: The following import is for registering the method tables
 from .noise import native as native
 from .qasm2 import uop as uop, core as core, glob as glob, parallel as parallel
-from .squin import gate as gate, noise as noise, qubit as qubit
+from .squin import gate as gate, noise as noise, qubit as qubit, annotate as annotate
 from .device import (
     StackMemorySimulator as StackMemorySimulator,
     DynamicMemorySimulator as DynamicMemorySimulator,

--- a/src/bloqade/pyqrack/squin/annotate.py
+++ b/src/bloqade/pyqrack/squin/annotate.py
@@ -1,0 +1,17 @@
+from kirin import interp
+
+from bloqade.pyqrack.base import PyQrackInterpreter
+from bloqade.decoders.dialects import annotate
+
+
+@annotate.dialect.register(key="pyqrack")
+class PyQrackAnnotateMethods(interp.MethodTable):
+    @interp.impl(annotate.stmts.SetDetector)
+    @interp.impl(annotate.stmts.SetObservable)
+    def ignore_annotation(
+        self,
+        interp: PyQrackInterpreter,
+        frame: interp.Frame,
+        stmt: annotate.stmts.SetDetector | annotate.stmts.SetObservable,
+    ):
+        return tuple(None for _ in stmt.results)

--- a/test/cirq_utils/test_cirq_to_squin.py
+++ b/test/cirq_utils/test_cirq_to_squin.py
@@ -505,3 +505,20 @@ def test_zzpow_odd_integer_exponent_unitary():
 
     populated = [i for i, a in enumerate(ket) if abs(a) > 1e-6]
     assert populated == [1]
+
+
+def test_squin_annotations_are_ignored_when_emitting_cirq():
+    @squin.kernel
+    def annotated():
+        q = squin.qalloc(2)
+        squin.h(q[0])
+        ms = squin.broadcast.measure(q)
+        squin.set_detector([ms[0]], coordinates=(0,))
+        squin.set_observable([ms[1]])
+
+    circuit = emit_circuit(annotated)
+    operations = list(circuit.all_operations())
+
+    assert len(operations) == 2
+    assert isinstance(operations[0].gate, cirq.HPowGate)
+    assert isinstance(operations[1].gate, cirq.MeasurementGate)

--- a/test/pyqrack/test_target.py
+++ b/test/pyqrack/test_target.py
@@ -6,7 +6,7 @@ import pytest
 from kirin import ir
 from kirin.dialects import ilist
 
-from bloqade import qasm2
+from bloqade import squin, qasm2
 from bloqade.pyqrack import PyQrack, CRegister, PyQrackQubit, StackMemorySimulator, reg
 
 
@@ -218,3 +218,22 @@ def test_loads_with_return():
 
     assert isinstance(result, CRegister)
     assert result[0] == 1
+
+
+def test_squin_annotations_are_ignored_by_pyqrack():
+    @squin.kernel
+    def annotated():
+        q = squin.qalloc(2)
+        squin.x(q[0])
+        ms = squin.broadcast.measure(q)
+        squin.set_detector([ms[0]], coordinates=(0,))
+        squin.set_observable([ms[1]])
+
+        return ms
+
+    result = StackMemorySimulator(min_qubits=2).run(annotated)
+
+    assert list(result) == [
+        reg.MeasurementResultValue.One,
+        reg.MeasurementResultValue.Zero,
+    ]


### PR DESCRIPTION
Fixes #628.

This adds no-op implementations for decoder annotation statements when lowering/running through the Cirq emit and PyQrack backends. The methods return one placeholder value per statement result so Kirin frame assignment can continue while the backends ignore detector/observable metadata.

Tests:
- `.venv/bin/python -m pytest test/pyqrack/test_target.py test/cirq_utils/test_cirq_to_squin.py::test_squin_annotations_are_ignored_when_emitting_cirq -q`
- `.venv/bin/python -m py_compile src/bloqade/cirq_utils/emit/annotate.py src/bloqade/pyqrack/squin/annotate.py`
- `git diff --check`

Disclosure: this patch was prepared with AI assistance and manually reviewed before submission.