### PR TITLE
feat: added more descriptive tsim import error msg

### DIFF
--- a/src/bloqade/tsim/circuit.py
+++ b/src/bloqade/tsim/circuit.py
@@ -7,15 +7,16 @@ try:
 
     _Circuit = tsim.Circuit
 except ImportError as _tsim_import_error:
-    _TSIM_IMPORT_ERROR = _tsim_import_error
 
     class _MissingTsimCircuit:
+        _import_error = _tsim_import_error
+
         def __init__(self, *args, **kwargs):
             raise ImportError(
                 "tsim is required for bloqade.tsim.Circuit. "
                 'Install with: pip install "bloqade-circuit[tsim]". '
-                f"Tsim import error: {_TSIM_IMPORT_ERROR}"
-            ) from _TSIM_IMPORT_ERROR
+                f"Tsim import error: {self._import_error}"
+            ) from self._import_error
 
     _Circuit = _MissingTsimCircuit
 

--- a/src/bloqade/tsim/circuit.py
+++ b/src/bloqade/tsim/circuit.py
@@ -6,14 +6,16 @@ try:
     import tsim
 
     _Circuit = tsim.Circuit
-except ImportError:
+except ImportError as _tsim_import_error:
+    _TSIM_IMPORT_ERROR = _tsim_import_error
 
     class _MissingTsimCircuit:
         def __init__(self, *args, **kwargs):
             raise ImportError(
                 "tsim is required for bloqade.tsim.Circuit. "
-                'Install with: pip install "bloqade-circuit[tsim]"'
-            )
+                'Install with: pip install "bloqade-circuit[tsim]". '
+                f"Tsim import error: {_TSIM_IMPORT_ERROR}"
+            ) from _TSIM_IMPORT_ERROR
 
     _Circuit = _MissingTsimCircuit
 


### PR DESCRIPTION
closes https://github.com/QuEraComputing/bloqade-circuit/issues/837

Now, the error message is 

```
---------------------------------------------------------------------------
ModuleNotFoundError                       Traceback (most recent call last)
File ~/Desktop/qmain/personal-workspace/bloqade-circuit/src/bloqade/tsim/circuit.py:6
      5 try:
----> 6     import tsim
      8     _Circuit = tsim.Circuit

File ~/Desktop/qmain/personal-workspace/bloqade-circuit/.venv/lib/python3.12/site-packages/tsim/__init__.py:19
     17 __version__ = "0.1.4"
---> 19 from tsim.circuit import Circuit as Circuit
     20 from tsim.sampler import (
     21     CompiledDetectorSampler as CompiledDetectorSampler,
     22     CompiledMeasurementSampler as CompiledMeasurementSampler,
     23 )

File ~/Desktop/qmain/personal-workspace/bloqade-circuit/.venv/lib/python3.12/site-packages/tsim/circuit.py:14
      5 from typing import (
      6     TYPE_CHECKING,
      7     Any,
   (...)     11     overload,
     12 )
---> 14 import pyzx_param as zx
     15 import stim

File ~/Desktop/qmain/personal-workspace/bloqade-circuit/.venv/lib/python3.12/site-packages/pyzx_param/__init__.py:48
     47 from . import simulate
---> 48 from . import editor
     49 from . import routing

File ~/Desktop/qmain/personal-workspace/bloqade-circuit/.venv/lib/python3.12/site-packages/pyzx_param/editor.py:38
     37 if get_mode() == 'notebook':
---> 38 	import ipywidgets as widgets
     39 	from traitlets import Unicode, validate, Bool, Int, Float

ModuleNotFoundError: No module named 'ipywidgets'

The above exception was the direct cause of the following exception:

ImportError                               Traceback (most recent call last)
Cell In[3], line 1
----> 1 test_circ = Circuit(test_kernel)

File ~/Desktop/qmain/personal-workspace/bloqade-circuit/src/bloqade/tsim/circuit.py:48, in Circuit.__init__(self, kernel, insert_ticks, *args, **kwargs)
     46 if isinstance(kernel, ir.Method):
     47     kernel = _codegen(kernel, insert_ticks=insert_ticks)
---> 48 super().__init__(kernel, *args, **kwargs)

File ~/Desktop/qmain/personal-workspace/bloqade-circuit/src/bloqade/tsim/circuit.py:14, in _MissingTsimCircuit.__init__(self, *args, **kwargs)
     13 def __init__(self, *args, **kwargs):
---> 14     raise ImportError(
     15         "tsim is required for bloqade.tsim.Circuit. "
     16         'Install with: pip install "bloqade-circuit[tsim]". '
     17         f"Tsim import error: {_TSIM_IMPORT_ERROR}"
     18     ) from _TSIM_IMPORT_ERROR

ImportError: tsim is required for bloqade.tsim.Circuit. Install with: pip install "bloqade-circuit[tsim]". Tsim import error: No module named 'ipywidgets'
```