### PR TITLE
feat: added helper kernel for shorthand input format

### DIFF
--- a/src/bloqade/squin/__init__.py
+++ b/src/bloqade/squin/__init__.py
@@ -1,3 +1,5 @@
+"""Various standard library functions re-exported."""
+
 from bloqade.decoders.dialects import annotate as annotate
 from bloqade.decoders.dialects.annotate import (
     set_detector as set_detector,
@@ -52,6 +54,7 @@ from .stdlib.simple import (
     correlated_qubit_loss as correlated_qubit_loss,
     two_qubit_pauli_channel as two_qubit_pauli_channel,
     single_qubit_pauli_channel as single_qubit_pauli_channel,
+    two_qubit_pauli_channel_shorthand as two_qubit_pauli_channel_shorthand,
 )
 from .analysis.fidelity import impls as impls
 from .analysis.validation.simple_nocloning import (  # noqa: F401

--- a/src/bloqade/squin/stdlib/simple/__init__.py
+++ b/src/bloqade/squin/stdlib/simple/__init__.py
@@ -1,3 +1,5 @@
+"""Standard library functions for gate and noise operations."""
+
 from .gate import (
     h as h,
     s as s,
@@ -33,4 +35,5 @@ from .noise import (
     correlated_qubit_loss as correlated_qubit_loss,
     two_qubit_pauli_channel as two_qubit_pauli_channel,
     single_qubit_pauli_channel as single_qubit_pauli_channel,
+    two_qubit_pauli_channel_shorthand as two_qubit_pauli_channel_shorthand,
 )

--- a/src/bloqade/squin/stdlib/simple/noise.py
+++ b/src/bloqade/squin/stdlib/simple/noise.py
@@ -84,6 +84,65 @@ def two_qubit_pauli_channel(
 
 
 @kernel
+def _two_qubit_pauli_probability(
+    probabilities: ilist.IList[tuple[str, float], Any], pauli: str
+) -> float:
+    probability = 0.0
+    for pair in probabilities:
+        current_probability = probability
+        if pair[0] == pauli:
+            current_probability = pair[1]
+        probability = current_probability
+    return probability
+
+
+@kernel
+def two_qubit_pauli_channel_shorthand(
+    probabilities: ilist.IList[tuple[str, float], Any], control: Qubit, target: Qubit
+) -> None:
+    """
+    A shorthand function for passing in a list of tuples of two-qubit Pauli products and corresponding
+    probabilities, and randomly selects one of the Pauli products weighted by its probability.
+
+    Example:
+    two_qubit_pauli_channel_shorthand([("XX", 0.1), ("YI", 0.2), ("IZ": 0.3)], control, target)
+
+    will apply "XX" with probability 0.1, "YI" with probability 0.2, "IZ" with probability 0.3. No error is applied with probability 0.4.
+
+    Internally, this will just call two_qubit_pauli_channel.
+
+    **NOTES**
+    1. If a Pauli string is defined twice in the implementation, the last version will be used. For example, for [("XX", 0.1), ("XX", 0.3)], this would be the same as
+    [("XX", 0.3)].
+    2. The probabilities list can be of any length; we just convert the last N elements to a list of 15 probabilities.
+    3. Strings that are not in `{IX, IY, IZ, XI, XX, XY, XZ, YI, YX, YY, YZ, ZI, ZX, ZY, ZZ}` are ignored.
+    """
+    two_qubit_pauli_channel(
+        ilist.IList(
+            [
+                _two_qubit_pauli_probability(probabilities, "IX"),
+                _two_qubit_pauli_probability(probabilities, "IY"),
+                _two_qubit_pauli_probability(probabilities, "IZ"),
+                _two_qubit_pauli_probability(probabilities, "XI"),
+                _two_qubit_pauli_probability(probabilities, "XX"),
+                _two_qubit_pauli_probability(probabilities, "XY"),
+                _two_qubit_pauli_probability(probabilities, "XZ"),
+                _two_qubit_pauli_probability(probabilities, "YI"),
+                _two_qubit_pauli_probability(probabilities, "YX"),
+                _two_qubit_pauli_probability(probabilities, "YY"),
+                _two_qubit_pauli_probability(probabilities, "YZ"),
+                _two_qubit_pauli_probability(probabilities, "ZI"),
+                _two_qubit_pauli_probability(probabilities, "ZX"),
+                _two_qubit_pauli_probability(probabilities, "ZY"),
+                _two_qubit_pauli_probability(probabilities, "ZZ"),
+            ]
+        ),
+        control,
+        target,
+    )
+
+
+@kernel
 def qubit_loss(p: float, qubit: Qubit) -> None:
     """
     Apply a qubit loss channel to the given qubit.

--- a/test/squin/test_stdlib_shorthands.py
+++ b/test/squin/test_stdlib_shorthands.py
@@ -226,3 +226,86 @@ def test_two_qubit_pauli_channel():
 
     sim = StackMemorySimulator(min_qubits=2)
     sim.run(main)
+
+
+def test_two_qubit_pauli_channel_shorthand():
+    @squin.kernel
+    def main():
+        q = squin.qalloc(2)
+        probabilities = [("XX", 0.0001), ("YY", 0.0001), ("ZZ", 0.0001)]
+        squin.two_qubit_pauli_channel_shorthand(probabilities, q[0], q[1])
+
+    main.print()
+
+    sim = StackMemorySimulator(min_qubits=2)
+    sim.run(main)
+
+
+def test_two_qubit_pauli_channel_shorthand_duplicate_pauli_string_runs():
+    @squin.kernel
+    def main():
+        q = squin.qalloc(2)
+        probabilities = [("XX", 0.0001), ("XX", 0.0002)]
+        squin.two_qubit_pauli_channel_shorthand(probabilities, q[0], q[1])
+
+    main.print()
+
+    sim = StackMemorySimulator(min_qubits=2)
+    sim.run(main)
+
+
+def test_two_qubit_pauli_channel_shorthand_more_than_fifteen_entries_runs():
+    @squin.kernel
+    def main():
+        q = squin.qalloc(2)
+        probabilities = [
+            ("IX", 0.0001),
+            ("IY", 0.0001),
+            ("IZ", 0.0001),
+            ("XI", 0.0001),
+            ("XX", 0.0001),
+            ("XY", 0.0001),
+            ("XZ", 0.0001),
+            ("YI", 0.0001),
+            ("YX", 0.0001),
+            ("YY", 0.0001),
+            ("YZ", 0.0001),
+            ("ZI", 0.0001),
+            ("ZX", 0.0001),
+            ("ZY", 0.0001),
+            ("ZZ", 0.0001),
+            ("XX", 0.0001),
+        ]
+        squin.two_qubit_pauli_channel_shorthand(probabilities, q[0], q[1])
+
+    main.print()
+
+    sim = StackMemorySimulator(min_qubits=2)
+    sim.run(main)
+
+
+def test_two_qubit_pauli_channel_shorthand_unknown_pauli_string_runs():
+    @squin.kernel
+    def main():
+        q = squin.qalloc(2)
+        probabilities = [("AB", 0.0001), ("XX", 0.0001)]
+        squin.two_qubit_pauli_channel_shorthand(probabilities, q[0], q[1])
+
+    main.print()
+
+    sim = StackMemorySimulator(min_qubits=2)
+    sim.run(main)
+
+
+def test_two_qubit_pauli_channel_shorthand_negative_probability_lowers():
+    @squin.kernel
+    def main():
+        q = squin.qalloc(2)
+        probabilities = [("XX", -0.0001)]
+        squin.two_qubit_pauli_channel_shorthand(probabilities, q[0], q[1])
+
+    main.print()
+
+    sim = StackMemorySimulator(min_qubits=2)
+    with pytest.raises(AssertionError, match="Invalid Pauli error probabilities"):
+        sim.run(main)


### PR DESCRIPTION
Alternative solution to address https://github.com/QuEraComputing/bloqade-circuit/issues/341 .

Basically, we define a helper kernel that takes in a list of tuples of (str, float) that specify the pauli products and probabilities of applying the pauli products.

Example:

two_qubit_pauli_channel_shorthand([("XX", 0.1), ("YI", 0.2), ("IZ": 0.3)], control, target)

However, we don't do validation in the kernel, so the following edge cases will not error but will have implementation-specific behavior:

- duplicate strings in the probabilities list (seeing "XX" twice)
- length > 15
- strings that lie outside of {IX, IY, IZ, XI, XX, XY, XZ, YI, YX, YY, YZ, ZI, ZX, ZY, ZZ}