### PR TITLE
Implementation with two lists for syntactic sugar for two qubit pauli channel

### DIFF
--- a/src/bloqade/cirq_utils/emit/noise.py
+++ b/src/bloqade/cirq_utils/emit/noise.py
@@ -44,6 +44,7 @@ class __EmitCirqNoiseMethods(MethodTable):
         p = frame.get(stmt.p)
         controls = frame.get(stmt.controls)
         targets = frame.get(stmt.targets)
+        self.check_two_qubit_lengths(controls, targets)
         cirq_qubits = [(ctrl, target) for ctrl, target in zip(controls, targets)]
         cirq_op = cirq.depolarize(p, n_qubits=2).on_each(cirq_qubits)
         interp.circuit.append(cirq_op)
@@ -80,6 +81,7 @@ class __EmitCirqNoiseMethods(MethodTable):
 
         controls = frame.get(stmt.controls)
         targets = frame.get(stmt.targets)
+        self.check_two_qubit_lengths(controls, targets)
         cirq_qubits = [(ctrl, target) for ctrl, target in zip(controls, targets)]
 
         cirq_op = cirq.asymmetric_depolarize(
@@ -88,3 +90,10 @@ class __EmitCirqNoiseMethods(MethodTable):
         interp.circuit.append(cirq_op)
 
         return ()
+
+    def check_two_qubit_lengths(self, controls, targets):
+        if len(controls) != len(targets):
+            raise ValueError(
+                "Two-qubit noise channels require controls and targets to have "
+                f"the same length, got {len(controls)} and {len(targets)}"
+            )

--- a/src/bloqade/pyqrack/squin/noise/native.py
+++ b/src/bloqade/pyqrack/squin/noise/native.py
@@ -14,6 +14,7 @@ from bloqade.squin.noise._dialect import dialect as squin_noise_dialect
 
 @squin_noise_dialect.register(key="pyqrack")
 class PyQrackMethods(interp.MethodTable):
+    """PyQrack interpreter implementations for Squin noise statements."""
 
     single_pauli_choices = ("i", "x", "y", "z")
     two_pauli_choices = (
@@ -39,6 +40,7 @@ class PyQrackMethods(interp.MethodTable):
     def depolarize(
         self, interp: PyQrackInterpreter, frame: interp.Frame, stmt: Depolarize
     ):
+        """Apply a single-qubit depolarizing channel."""
         p = frame.get(stmt.p)
         ps = [p / 3.0] * 3
         qubits = frame.get(stmt.qubits)
@@ -48,6 +50,7 @@ class PyQrackMethods(interp.MethodTable):
     def depolarize2(
         self, interp: PyQrackInterpreter, frame: interp.Frame, stmt: Depolarize2
     ):
+        """Apply a two-qubit depolarizing channel."""
         p = frame.get(stmt.p)
         ps = [p / 15.0] * 15
         controls = frame.get(stmt.controls)
@@ -61,6 +64,7 @@ class PyQrackMethods(interp.MethodTable):
         frame: interp.Frame,
         stmt: SingleQubitPauliChannel,
     ):
+        """Apply a single-qubit Pauli channel."""
         px = frame.get(stmt.px)
         py = frame.get(stmt.py)
         pz = frame.get(stmt.pz)
@@ -74,6 +78,7 @@ class PyQrackMethods(interp.MethodTable):
         frame: interp.Frame,
         stmt: TwoQubitPauliChannel,
     ):
+        """Apply a two-qubit Pauli channel."""
         ps = frame.get(stmt.probabilities)
         controls = frame.get(stmt.controls)
         targets = frame.get(stmt.targets)
@@ -83,6 +88,7 @@ class PyQrackMethods(interp.MethodTable):
     def qubit_loss(
         self, interp: PyQrackInterpreter, frame: interp.Frame, stmt: QubitLoss
     ):
+        """Apply independent qubit loss."""
         p = frame.get(stmt.p)
         qubits: list[PyQrackQubit] = frame.get(stmt.qubits)
         for qbit in qubits:
@@ -93,6 +99,7 @@ class PyQrackMethods(interp.MethodTable):
     def correlated_qubit_loss(
         self, interp: PyQrackInterpreter, frame: interp.Frame, stmt: CorrelatedQubitLoss
     ):
+        """Apply correlated loss to each qubit group."""
         p = frame.get(stmt.p)
         qubits: list[list[PyQrackQubit]] = frame.get(stmt.qubits)
         for qubit_group in qubits:
@@ -106,6 +113,7 @@ class PyQrackMethods(interp.MethodTable):
         ps: list[float],
         qubits: list[PyQrackQubit],
     ):
+        """Sample and apply single-qubit Pauli errors."""
         pi = 1 - sum(ps)
         probs = [pi] + ps
 
@@ -122,6 +130,13 @@ class PyQrackMethods(interp.MethodTable):
         controls: list[PyQrackQubit],
         targets: list[PyQrackQubit],
     ):
+        """Sample and apply paired two-qubit Pauli errors."""
+        if len(controls) != len(targets):
+            raise ValueError(
+                "Two-qubit noise channels require controls and targets to have "
+                f"the same length, got {len(controls)} and {len(targets)}"
+            )
+
         pii = 1 - sum(ps)
         probs = [pii] + ps
         assert all(0 <= x <= 1 for x in probs), "Invalid Pauli error probabilities"
@@ -132,6 +147,7 @@ class PyQrackMethods(interp.MethodTable):
             self.apply_pauli_error(which[1], target)
 
     def apply_pauli_error(self, which: str, qbit: PyQrackQubit):
+        """Apply one concrete Pauli operation to a PyQrack qubit."""
         if not qbit.is_active() or which == "i":
             return
 

--- a/src/bloqade/squin/noise/stmts.py
+++ b/src/bloqade/squin/noise/stmts.py
@@ -4,7 +4,7 @@ from collections.abc import Sequence
 
 from kirin import ir, types, lowering
 from kirin.decl import info, statement
-from kirin.dialects import py, ilist
+from kirin.dialects import py, func, ilist
 from kirin.lowering import BuildError
 
 from bloqade.types import QubitType
@@ -127,6 +127,15 @@ def _two_qubit_pauli_probabilities(
     return full_probabilities
 
 
+_two_qubit_pauli_channel_broadcast_callee: ir.Method | None = None
+
+
+def register_two_qubit_pauli_channel_broadcast_callee(callee: ir.Method) -> None:
+    """Defines a global kernel that other kernels can invoke."""
+    global _two_qubit_pauli_channel_broadcast_callee
+    _two_qubit_pauli_channel_broadcast_callee = callee
+
+
 @dataclass(frozen=True)
 class FromPythonCallTwoQubitPauliChannelSimple(lowering.FromPythonCall):
     """
@@ -140,40 +149,133 @@ class FromPythonCallTwoQubitPauliChannelSimple(lowering.FromPythonCall):
         """
         Custom lowering that allows for a list of probabilities or two lists (one of paulis and one of probabilities.)
         """
-        if node.keywords:
-            raise BuildError(
-                "two_qubit_pauli_channel does not support keyword arguments"
+        keyword_names = {keyword.arg for keyword in node.keywords}
+        shorthand = (
+            len(node.args) == 4
+            or "paulis" in keyword_names
+            or (
+                len(node.args) == 2
+                and bool(keyword_names & {"control", "controls"})
+                and bool(keyword_names & {"target", "targets"})
+            )
+        )
+
+        if shorthand:
+            (
+                paulis_node,
+                probabilities_node,
+                controls_node,
+                targets_node,
+            ) = _extract_call_arguments(
+                node,
+                ("paulis", "probabilities", "controls", "targets"),
+                {"control": "controls", "target": "targets"},
             )
 
-        if len(node.args) == 3:
-            probabilities = state.lower(node.args[0]).expect_one()
-            control = state.lower(node.args[1]).expect_one()
-            target = state.lower(node.args[2]).expect_one()
-        elif len(node.args) == 4:
-            paulis = _constant_sequence_from_ast(state, node.args[0])
-            shorthand_probabilities = _constant_sequence_from_ast(state, node.args[1])
+            paulis = _constant_sequence_from_ast(state, paulis_node)
+            shorthand_probabilities = _constant_sequence_from_ast(
+                state, probabilities_node
+            )
             probabilities = _lower_probabilities(
                 state,
                 _two_qubit_pauli_probabilities(paulis, shorthand_probabilities),
             )
-            control = state.lower(node.args[2]).expect_one()
-            target = state.lower(node.args[3]).expect_one()
+            controls, broadcast_controls = _lower_qubit_argument(state, controls_node)
+            targets, broadcast_targets = _lower_qubit_argument(state, targets_node)
         else:
-            raise BuildError(
-                "two_qubit_pauli_channel expects either "
-                "(probabilities, control, target) or "
-                "(paulis, probabilities, control, target)"
+            probabilities_node, controls_node, targets_node = _extract_call_arguments(
+                node,
+                ("probabilities", "controls", "targets"),
+                {"control": "controls", "target": "targets"},
+            )
+            probabilities = state.lower(probabilities_node).expect_one()
+            controls, broadcast_controls = _lower_qubit_argument(state, controls_node)
+            targets, broadcast_targets = _lower_qubit_argument(state, targets_node)
+
+        if broadcast_controls or broadcast_targets:
+            if _two_qubit_pauli_channel_broadcast_callee is None:
+                raise BuildError(
+                    "broadcast two_qubit_pauli_channel lowering is not registered"
+                )
+
+            return state.current_frame.push(
+                func.Invoke(
+                    (probabilities, controls, targets),
+                    callee=_two_qubit_pauli_channel_broadcast_callee,
+                )
             )
 
-        controls = state.current_frame.push(
-            ilist.New(values=(control,), elem_type=QubitType)
-        ).result
-        targets = state.current_frame.push(
-            ilist.New(values=(target,), elem_type=QubitType)
-        ).result
         return state.current_frame.push(
             TwoQubitPauliChannel(probabilities, controls, targets)
         )
+
+
+def _extract_call_arguments(
+    node: ast.Call, names: tuple[str, ...], aliases: dict[str, str]
+) -> tuple[ast.AST, ...]:
+    if len(node.args) > len(names):
+        raise BuildError(
+            "two_qubit_pauli_channel expects either "
+            "(probabilities, control, target) or "
+            "(paulis, probabilities, control, target)"
+        )
+
+    values = dict(zip(names, node.args))
+    for keyword in node.keywords:
+        if keyword.arg is None:
+            raise BuildError(
+                "two_qubit_pauli_channel does not support unpacked keyword arguments"
+            )
+
+        name = aliases.get(keyword.arg, keyword.arg)
+        if name not in names:
+            raise BuildError(
+                f"Unexpected keyword argument {keyword.arg!r} "
+                "for two_qubit_pauli_channel"
+            )
+        if name in values:
+            raise BuildError(
+                f"Argument {keyword.arg!r} was passed more than once "
+                "to two_qubit_pauli_channel"
+            )
+        values[name] = keyword.value
+
+    missing = [name for name in names if name not in values]
+    if missing:
+        raise BuildError(f"Missing argument {missing[0]!r} for two_qubit_pauli_channel")
+
+    return tuple(values[name] for name in names)
+
+
+def _lower_qubit_argument(
+    state: lowering.State, node: ast.AST
+) -> tuple[ir.SSAValue, bool]:
+    value = state.lower(node).expect_one()
+    if value.type.is_subseteq(ilist.IListType[QubitType, types.Any]):
+        return value, True
+
+    if (
+        value.type.is_subseteq(QubitType)
+        or _is_scalar_index(node)
+        or _is_scalar_index_value(value)
+    ):
+        qubits = state.current_frame.push(
+            ilist.New(values=(value,), elem_type=QubitType)
+        ).result
+        return qubits, False
+
+    return value, True
+
+
+def _is_scalar_index(node: ast.AST) -> bool:
+    return isinstance(node, ast.Subscript) and not isinstance(node.slice, ast.Slice)
+
+
+def _is_scalar_index_value(value: ir.SSAValue) -> bool:
+    owner = value.owner
+    return isinstance(owner, py.indexing.GetItem) and owner.index.type.is_subseteq(
+        types.Int
+    )
 
 
 def _lower_probabilities(state: lowering.State, probabilities: Sequence[float]):

--- a/src/bloqade/squin/noise/stmts.py
+++ b/src/bloqade/squin/noise/stmts.py
@@ -1,19 +1,199 @@
+import ast
+from dataclasses import dataclass
+from collections.abc import Sequence
+
 from kirin import ir, types, lowering
 from kirin.decl import info, statement
-from kirin.dialects import ilist
+from kirin.dialects import py, ilist
+from kirin.lowering import BuildError
 
 from bloqade.types import QubitType
 
 from ._dialect import dialect
 
+PAULI_PRODUCT_ORDER = (
+    "IX",
+    "IY",
+    "IZ",
+    "XI",
+    "XX",
+    "XY",
+    "XZ",
+    "YI",
+    "YX",
+    "YY",
+    "YZ",
+    "ZI",
+    "ZX",
+    "ZY",
+    "ZZ",
+)
+
+_PAULI_PRODUCT_INDEX = {pauli: index for index, pauli in enumerate(PAULI_PRODUCT_ORDER)}
+
+_STATIC_SHORTHAND_ERROR = (
+    "Pauli shorthand arguments to two_qubit_pauli_channel must be statically "
+    "known. Use the full 15-probability signature for runtime values."
+)
+
+
+def _constant_sequence_from_ssa(value: ir.SSAValue) -> list:
+    owner = value.owner
+    if isinstance(owner, ilist.New):
+        return [_constant_from_ssa(item) for item in owner.values]
+
+    if isinstance(owner, py.constant.Constant):
+        data = owner.value.unwrap()
+        if isinstance(data, ilist.IList):
+            return list(data)
+        if isinstance(data, (list, tuple)):
+            return list(data)
+
+    raise BuildError(_STATIC_SHORTHAND_ERROR)
+
+
+def _constant_from_ssa(value: ir.SSAValue):
+    owner = value.owner
+    if isinstance(owner, py.constant.Constant):
+        return owner.value.unwrap()
+
+    raise BuildError(_STATIC_SHORTHAND_ERROR)
+
+
+def _constant_sequence_from_ast(state: lowering.State, node: ast.AST) -> list:
+    if isinstance(node, (ast.List, ast.Tuple)):
+        return [_constant_from_ast(state, item) for item in node.elts]
+
+    if isinstance(node, ast.Name):
+        local = state.current_frame.get_local(node.id)
+        if local is not None:
+            return _constant_sequence_from_ssa(local)
+
+    global_value = state.get_global(node, no_raise=True)
+    if global_value is not None:
+        data = global_value.data
+        if isinstance(data, ilist.IList):
+            return list(data)
+        if isinstance(data, (list, tuple)):
+            return list(data)
+
+    raise BuildError(_STATIC_SHORTHAND_ERROR)
+
+
+def _constant_from_ast(state: lowering.State, node: ast.AST):
+    if isinstance(node, ast.Constant):
+        return node.value
+
+    if isinstance(node, ast.Name):
+        local = state.current_frame.get_local(node.id)
+        if local is not None:
+            return _constant_from_ssa(local)
+
+    global_value = state.get_global(node, no_raise=True)
+    if global_value is not None:
+        return global_value.data
+
+    raise BuildError(_STATIC_SHORTHAND_ERROR)
+
+
+def _two_qubit_pauli_probabilities(
+    paulis: Sequence[object], probabilities: Sequence[object]
+) -> list[float]:
+    if len(paulis) != len(probabilities):
+        raise BuildError(
+            "Pauli shorthand arguments to two_qubit_pauli_channel must have the "
+            "same length"
+        )
+
+    full_probabilities = [0.0 for _ in PAULI_PRODUCT_ORDER]
+    seen: set[str] = set()
+    for pauli, probability in zip(paulis, probabilities):
+        if not isinstance(pauli, str):
+            raise BuildError(
+                "Pauli labels passed to two_qubit_pauli_channel must be strings"
+            )
+        if pauli not in _PAULI_PRODUCT_INDEX:
+            raise BuildError(f"Invalid two-qubit Pauli product {pauli!r}")
+        if pauli in seen:
+            raise BuildError(f"Duplicate two-qubit Pauli product {pauli!r}")
+        if not isinstance(probability, (int, float)):
+            raise BuildError(
+                "Probabilities passed to two_qubit_pauli_channel must be numbers"
+            )
+
+        seen.add(pauli)
+        full_probabilities[_PAULI_PRODUCT_INDEX[pauli]] = float(probability)
+
+    return full_probabilities
+
+
+@dataclass(frozen=True)
+class FromPythonCallTwoQubitPauliChannelSimple(lowering.FromPythonCall):
+    """
+    Custom lowering class that converts either an input that takes in a list of probabilities or two lists, one of paulis and one of
+    probabilities.
+    """
+
+    def lower(
+        self, stmt: type[ir.Statement], state: lowering.State, node: ast.Call
+    ) -> lowering.Result:
+        """
+        Custom lowering that allows for a list of probabilities or two lists (one of paulis and one of probabilities.)
+        """
+        if node.keywords:
+            raise BuildError(
+                "two_qubit_pauli_channel does not support keyword arguments"
+            )
+
+        if len(node.args) == 3:
+            probabilities = state.lower(node.args[0]).expect_one()
+            control = state.lower(node.args[1]).expect_one()
+            target = state.lower(node.args[2]).expect_one()
+        elif len(node.args) == 4:
+            paulis = _constant_sequence_from_ast(state, node.args[0])
+            shorthand_probabilities = _constant_sequence_from_ast(state, node.args[1])
+            probabilities = _lower_probabilities(
+                state,
+                _two_qubit_pauli_probabilities(paulis, shorthand_probabilities),
+            )
+            control = state.lower(node.args[2]).expect_one()
+            target = state.lower(node.args[3]).expect_one()
+        else:
+            raise BuildError(
+                "two_qubit_pauli_channel expects either "
+                "(probabilities, control, target) or "
+                "(paulis, probabilities, control, target)"
+            )
+
+        controls = state.current_frame.push(
+            ilist.New(values=(control,), elem_type=QubitType)
+        ).result
+        targets = state.current_frame.push(
+            ilist.New(values=(target,), elem_type=QubitType)
+        ).result
+        return state.current_frame.push(
+            TwoQubitPauliChannel(probabilities, controls, targets)
+        )
+
+
+def _lower_probabilities(state: lowering.State, probabilities: Sequence[float]):
+    values = tuple(state.get_literal(probability) for probability in probabilities)
+    return state.current_frame.push(
+        ilist.New(values=values, elem_type=types.Float)
+    ).result
+
 
 @statement
 class NoiseChannel(ir.Statement):
+    """A generic NoiseChannel statement."""
+
     traits = frozenset({lowering.FromPythonCall()})
 
 
 @statement
 class SingleQubitNoiseChannel(NoiseChannel):
+    """A generic single qubit noise channel statement."""
+
     # NOTE: we are not adding e.g. qubits here, since inheriting then will
     # change the order of the wrapper arguments
     pass
@@ -21,6 +201,8 @@ class SingleQubitNoiseChannel(NoiseChannel):
 
 @statement
 class TwoQubitNoiseChannel(NoiseChannel):
+    """A generic two qubit noise channel statement."""
+
     pass
 
 
@@ -53,10 +235,17 @@ class TwoQubitPauliChannel(TwoQubitNoiseChannel):
     """
 
     probabilities: ir.SSAValue = info.argument(
-        ilist.IListType[QubitType, types.Literal(15)]
+        ilist.IListType[types.Float, types.Literal(15)]
     )
     controls: ir.SSAValue = info.argument(ilist.IListType[QubitType, N])
     targets: ir.SSAValue = info.argument(ilist.IListType[QubitType, N])
+
+
+@statement(dialect=dialect)
+class TwoQubitPauliChannelSimple(ir.Statement):
+    """Custom statement that defines lowering that allows for different input shapes for a list of probabilities or two lists."""
+
+    traits = frozenset({FromPythonCallTwoQubitPauliChannelSimple()})
 
 
 @statement(dialect=dialect)

--- a/src/bloqade/squin/noise/stmts.py
+++ b/src/bloqade/squin/noise/stmts.py
@@ -4,7 +4,7 @@ from collections.abc import Sequence
 
 from kirin import ir, types, lowering
 from kirin.decl import info, statement
-from kirin.dialects import py, func, ilist
+from kirin.dialects import py, ilist
 from kirin.lowering import BuildError
 
 from bloqade.types import QubitType
@@ -127,15 +127,6 @@ def _two_qubit_pauli_probabilities(
     return full_probabilities
 
 
-_two_qubit_pauli_channel_broadcast_callee: ir.Method | None = None
-
-
-def register_two_qubit_pauli_channel_broadcast_callee(callee: ir.Method) -> None:
-    """Defines a global kernel that other kernels can invoke."""
-    global _two_qubit_pauli_channel_broadcast_callee
-    _two_qubit_pauli_channel_broadcast_callee = callee
-
-
 @dataclass(frozen=True)
 class FromPythonCallTwoQubitPauliChannelSimple(lowering.FromPythonCall):
     """
@@ -180,8 +171,8 @@ class FromPythonCallTwoQubitPauliChannelSimple(lowering.FromPythonCall):
                 state,
                 _two_qubit_pauli_probabilities(paulis, shorthand_probabilities),
             )
-            controls, broadcast_controls = _lower_qubit_argument(state, controls_node)
-            targets, broadcast_targets = _lower_qubit_argument(state, targets_node)
+            controls = _lower_qubit_argument(state, controls_node)
+            targets = _lower_qubit_argument(state, targets_node)
         else:
             probabilities_node, controls_node, targets_node = _extract_call_arguments(
                 node,
@@ -189,21 +180,8 @@ class FromPythonCallTwoQubitPauliChannelSimple(lowering.FromPythonCall):
                 {"control": "controls", "target": "targets"},
             )
             probabilities = state.lower(probabilities_node).expect_one()
-            controls, broadcast_controls = _lower_qubit_argument(state, controls_node)
-            targets, broadcast_targets = _lower_qubit_argument(state, targets_node)
-
-        if broadcast_controls or broadcast_targets:
-            if _two_qubit_pauli_channel_broadcast_callee is None:
-                raise BuildError(
-                    "broadcast two_qubit_pauli_channel lowering is not registered"
-                )
-
-            return state.current_frame.push(
-                func.Invoke(
-                    (probabilities, controls, targets),
-                    callee=_two_qubit_pauli_channel_broadcast_callee,
-                )
-            )
+            controls = _lower_qubit_argument(state, controls_node)
+            targets = _lower_qubit_argument(state, targets_node)
 
         return state.current_frame.push(
             TwoQubitPauliChannel(probabilities, controls, targets)
@@ -247,24 +225,21 @@ def _extract_call_arguments(
     return tuple(values[name] for name in names)
 
 
-def _lower_qubit_argument(
-    state: lowering.State, node: ast.AST
-) -> tuple[ir.SSAValue, bool]:
+def _lower_qubit_argument(state: lowering.State, node: ast.AST) -> ir.SSAValue:
     value = state.lower(node).expect_one()
     if value.type.is_subseteq(ilist.IListType[QubitType, types.Any]):
-        return value, True
+        return value
 
     if (
         value.type.is_subseteq(QubitType)
         or _is_scalar_index(node)
         or _is_scalar_index_value(value)
     ):
-        qubits = state.current_frame.push(
+        return state.current_frame.push(
             ilist.New(values=(value,), elem_type=QubitType)
         ).result
-        return qubits, False
 
-    return value, True
+    return value
 
 
 def _is_scalar_index(node: ast.AST) -> bool:
@@ -283,6 +258,35 @@ def _lower_probabilities(state: lowering.State, probabilities: Sequence[float]):
     return state.current_frame.push(
         ilist.New(values=values, elem_type=types.Float)
     ).result
+
+
+def check_static_lengths_match(controls: ir.SSAValue, targets: ir.SSAValue) -> None:
+    """Check equal control and target lengths when statically visible."""
+    controls_len = _static_ilist_length(controls)
+    targets_len = _static_ilist_length(targets)
+    if controls_len is None or targets_len is None:
+        return
+
+    if controls_len != targets_len:
+        raise ValueError(
+            "Two-qubit noise channels require controls and targets to have the "
+            f"same length, got {controls_len} and {targets_len}"
+        )
+
+
+def _static_ilist_length(value: ir.SSAValue) -> int | None:
+    if isinstance(value.owner, ilist.New):
+        return len(value.owner.values)
+
+    value_type = value.type
+    if not isinstance(value_type, types.Generic) or len(value_type.vars) < 2:
+        return None
+
+    length_type = value_type.vars[1]
+    if isinstance(length_type, types.Literal) and isinstance(length_type.data, int):
+        return length_type.data
+
+    return None
 
 
 @statement
@@ -339,8 +343,12 @@ class TwoQubitPauliChannel(TwoQubitNoiseChannel):
     probabilities: ir.SSAValue = info.argument(
         ilist.IListType[types.Float, types.Literal(15)]
     )
-    controls: ir.SSAValue = info.argument(ilist.IListType[QubitType, N])
-    targets: ir.SSAValue = info.argument(ilist.IListType[QubitType, N])
+    controls: ir.SSAValue = info.argument(ilist.IListType[QubitType, types.Any])
+    targets: ir.SSAValue = info.argument(ilist.IListType[QubitType, types.Any])
+
+    def check(self):
+        """Verify statically-known control and target lengths match."""
+        check_static_lengths_match(self.controls, self.targets)
 
 
 @statement(dialect=dialect)
@@ -375,8 +383,12 @@ class Depolarize2(TwoQubitNoiseChannel):
     """
 
     p: ir.SSAValue = info.argument(types.Float)
-    controls: ir.SSAValue = info.argument(ilist.IListType[QubitType, N])
-    targets: ir.SSAValue = info.argument(ilist.IListType[QubitType, N])
+    controls: ir.SSAValue = info.argument(ilist.IListType[QubitType, types.Any])
+    targets: ir.SSAValue = info.argument(ilist.IListType[QubitType, types.Any])
+
+    def check(self):
+        """Verify statically-known control and target lengths match."""
+        check_static_lengths_match(self.controls, self.targets)
 
 
 @statement(dialect=dialect)

--- a/src/bloqade/squin/stdlib/broadcast/noise.py
+++ b/src/bloqade/squin/stdlib/broadcast/noise.py
@@ -67,18 +67,6 @@ def single_qubit_pauli_channel(
     noise.single_qubit_pauli_channel(px, py, pz, qubits)
 
 
-@kernel
-def _two_qubit_pauli_channel(
-    probabilities: ilist.IList[float, Literal[15]],
-    controls: ilist.IList[Qubit, N],
-    targets: ilist.IList[Qubit, N],
-) -> None:
-    noise.two_qubit_pauli_channel(probabilities, controls, targets)
-
-
-stmts.register_two_qubit_pauli_channel_broadcast_callee(_two_qubit_pauli_channel)
-
-
 @overload
 def two_qubit_pauli_channel(
     probabilities: ilist.IList[float, Literal[15]],

--- a/src/bloqade/squin/stdlib/broadcast/noise.py
+++ b/src/bloqade/squin/stdlib/broadcast/noise.py
@@ -1,10 +1,11 @@
-from typing import Any, Literal, TypeVar
+from typing import Any, Literal, TypeVar, overload
 
 from kirin.dialects import ilist
+from kirin.lowering import wraps
 
 from bloqade.types import Qubit
 
-from ...noise import _interface as noise
+from ...noise import stmts, _interface as noise
 from ...groups import kernel
 
 
@@ -67,11 +68,36 @@ def single_qubit_pauli_channel(
 
 
 @kernel
-def two_qubit_pauli_channel(
+def _two_qubit_pauli_channel(
     probabilities: ilist.IList[float, Literal[15]],
     controls: ilist.IList[Qubit, N],
     targets: ilist.IList[Qubit, N],
 ) -> None:
+    noise.two_qubit_pauli_channel(probabilities, controls, targets)
+
+
+stmts.register_two_qubit_pauli_channel_broadcast_callee(_two_qubit_pauli_channel)
+
+
+@overload
+def two_qubit_pauli_channel(
+    probabilities: ilist.IList[float, Literal[15]],
+    controls: ilist.IList[Qubit, N],
+    targets: ilist.IList[Qubit, N],
+) -> None: ...
+
+
+@overload
+def two_qubit_pauli_channel(
+    paulis: list[str] | tuple[str, ...],
+    probabilities: list[float] | tuple[float, ...],
+    controls: ilist.IList[Qubit, N],
+    targets: ilist.IList[Qubit, N],
+) -> None: ...
+
+
+@wraps(stmts.TwoQubitPauliChannelSimple)
+def two_qubit_pauli_channel(*args) -> None:
     """
     Apply a Pauli product error with weighted `probabilities` to the set of control and target qubits.
 
@@ -86,7 +112,7 @@ def two_qubit_pauli_channel(
 
     **NOTE**: The order of the given probabilities must match the order of the list of Pauli products above!
     """
-    noise.two_qubit_pauli_channel(probabilities, controls, targets)
+    ...
 
 
 @kernel

--- a/src/bloqade/squin/stdlib/simple/noise.py
+++ b/src/bloqade/squin/stdlib/simple/noise.py
@@ -1,10 +1,12 @@
-from typing import Any, Literal, TypeVar
+from typing import Any, Literal, TypeVar, overload
 
 from kirin.dialects import ilist
+from kirin.lowering import wraps
 
 from bloqade.types import Qubit
 
 from .. import broadcast
+from ...noise import stmts
 from ...groups import kernel
 
 
@@ -61,10 +63,23 @@ def single_qubit_pauli_channel(px: float, py: float, pz: float, qubit: Qubit) ->
     broadcast.single_qubit_pauli_channel(px, py, pz, ilist.IList([qubit]))
 
 
-@kernel
+@overload
 def two_qubit_pauli_channel(
     probabilities: ilist.IList[float, Literal[15]], control: Qubit, target: Qubit
-) -> None:
+) -> None: ...
+
+
+@overload
+def two_qubit_pauli_channel(
+    paulis: list[str] | tuple[str, ...],
+    probabilities: list[float] | tuple[float, ...],
+    control: Qubit,
+    target: Qubit,
+) -> None: ...
+
+
+@wraps(stmts.TwoQubitPauliChannelSimple)
+def two_qubit_pauli_channel(*args) -> None:
     """
     Apply a Pauli product error with weighted `probabilities` to the pair of qubits.
 
@@ -78,9 +93,7 @@ def two_qubit_pauli_channel(
 
     **NOTE**: The order of the given probabilities must match the order of the list of Pauli products above!
     """
-    broadcast.two_qubit_pauli_channel(
-        probabilities, ilist.IList([control]), ilist.IList([target])
-    )
+    ...
 
 
 @kernel

--- a/test/cirq_utils/test_squin_noise_to_cirq.py
+++ b/test/cirq_utils/test_squin_noise_to_cirq.py
@@ -1,4 +1,6 @@
 import cirq
+import pytest
+from kirin.ir.exception import ValidationError
 
 from bloqade import squin
 from bloqade.cirq_utils import emit_circuit
@@ -44,3 +46,30 @@ def test_pauli_channel(run_sim: bool = False):
     if run_sim:
         sim = cirq.Simulator()
         sim.run(circuit)
+
+
+def test_two_qubit_noise_rejects_runtime_length_mismatch():
+    @squin.kernel
+    def main():
+        q = squin.qalloc(3)
+        ps = [
+            0.0001,
+            0.0001,
+            0.0001,
+            0.0001,
+            0.0001,
+            0.0001,
+            0.0001,
+            0.0001,
+            0.0001,
+            0.0001,
+            0.0001,
+            0.0001,
+            0.0001,
+            0.0001,
+            0.0001,
+        ]
+        squin.broadcast.two_qubit_pauli_channel(ps, q[:1], q[1:])
+
+    with pytest.raises(ValidationError, match="same length"):
+        emit_circuit(main)

--- a/test/pyqrack/squin/test_noise.py
+++ b/test/pyqrack/squin/test_noise.py
@@ -1,3 +1,5 @@
+import pytest
+
 from bloqade import squin
 from bloqade.pyqrack import PyQrack, PyQrackQubit, StackMemorySimulator
 
@@ -102,3 +104,31 @@ def test_depolarize2():
 
     sim = StackMemorySimulator(min_qubits=2)
     sim.run(main)
+
+
+def test_two_qubit_noise_rejects_runtime_length_mismatch():
+    @squin.kernel
+    def main():
+        q = squin.qalloc(3)
+        ps = [
+            0.0001,
+            0.0001,
+            0.0001,
+            0.0001,
+            0.0001,
+            0.0001,
+            0.0001,
+            0.0001,
+            0.0001,
+            0.0001,
+            0.0001,
+            0.0001,
+            0.0001,
+            0.0001,
+            0.0001,
+        ]
+        squin.broadcast.two_qubit_pauli_channel(ps, q[:1], q[1:])
+
+    sim = StackMemorySimulator(min_qubits=3)
+    with pytest.raises(ValueError, match="same length"):
+        sim.run(main)

--- a/test/squin/test_stdlib_shorthands.py
+++ b/test/squin/test_stdlib_shorthands.py
@@ -257,6 +257,51 @@ def test_two_qubit_pauli_channel_shorthand_literal_lists():
     sim.run(main)
 
 
+def test_two_qubit_pauli_channel_broadcast_shorthand():
+    @squin.kernel
+    def main():
+        controls = squin.qalloc(2)
+        targets = squin.qalloc(2)
+        squin.broadcast.two_qubit_pauli_channel(
+            ["XX", "ZZ"], [0.1, 0.15], controls, targets
+        )
+
+    main.print()
+
+    sim = StackMemorySimulator(min_qubits=4)
+    sim.run(main)
+
+
+def test_two_qubit_pauli_channel_broadcast_full_signature():
+    @squin.kernel
+    def main():
+        controls = squin.qalloc(2)
+        targets = squin.qalloc(2)
+        ps = [
+            0.0001,
+            0.0001,
+            0.0001,
+            0.0001,
+            0.0001,
+            0.0001,
+            0.0001,
+            0.0001,
+            0.0001,
+            0.0001,
+            0.0001,
+            0.0001,
+            0.0001,
+            0.0001,
+            0.0001,
+        ]
+        squin.broadcast.two_qubit_pauli_channel(ps, controls, targets)
+
+    main.print()
+
+    sim = StackMemorySimulator(min_qubits=4)
+    sim.run(main)
+
+
 def test_two_qubit_pauli_channel_shorthand_rejects_runtime_lists():
     with pytest.raises(BuildError, match="statically known"):
 

--- a/test/squin/test_stdlib_shorthands.py
+++ b/test/squin/test_stdlib_shorthands.py
@@ -1,4 +1,5 @@
 import pytest
+from kirin.lowering import BuildError
 
 from bloqade import squin
 from bloqade.types import Qubit
@@ -226,3 +227,49 @@ def test_two_qubit_pauli_channel():
 
     sim = StackMemorySimulator(min_qubits=2)
     sim.run(main)
+
+
+def test_two_qubit_pauli_channel_shorthand_local_lists():
+    @squin.kernel
+    def main():
+        q = squin.qalloc(2)
+        paulis = ["XX", "YY", "ZZ"]
+        probs = [0.1, 0.2, 0.15]
+        squin.two_qubit_pauli_channel(paulis, probs, q[0], q[1])
+
+    output = main.print_str()
+    assert "IList([0.0, 0.0, 0.0, 0.0, 0.1" in output
+    assert "0.2, 0.0, 0.0, 0.0, 0.0, 0.15])" in output
+
+    sim = StackMemorySimulator(min_qubits=2)
+    sim.run(main)
+
+
+def test_two_qubit_pauli_channel_shorthand_literal_lists():
+    @squin.kernel
+    def main():
+        q = squin.qalloc(2)
+        squin.two_qubit_pauli_channel(["XX", "ZZ"], [0.1, 0.15], q[0], q[1])
+
+    main.print()
+
+    sim = StackMemorySimulator(min_qubits=2)
+    sim.run(main)
+
+
+def test_two_qubit_pauli_channel_shorthand_rejects_runtime_lists():
+    with pytest.raises(BuildError, match="statically known"):
+
+        @squin.kernel
+        def main(paulis: list[str], probs: list[float]):
+            q = squin.qalloc(2)
+            squin.two_qubit_pauli_channel(paulis, probs, q[0], q[1])
+
+
+def test_two_qubit_pauli_channel_shorthand_rejects_unknown_pauli():
+    with pytest.raises(BuildError, match="Invalid two-qubit Pauli product"):
+
+        @squin.kernel
+        def main():
+            q = squin.qalloc(2)
+            squin.two_qubit_pauli_channel(["AA"], [0.1], q[0], q[1])

--- a/test/squin/test_stdlib_shorthands.py
+++ b/test/squin/test_stdlib_shorthands.py
@@ -1,5 +1,6 @@
 import pytest
 from kirin.lowering import BuildError
+from kirin.ir.exception import ValidationError
 
 from bloqade import squin
 from bloqade.types import Qubit
@@ -300,6 +301,32 @@ def test_two_qubit_pauli_channel_broadcast_full_signature():
 
     sim = StackMemorySimulator(min_qubits=4)
     sim.run(main)
+
+
+def test_two_qubit_pauli_channel_broadcast_rejects_static_length_mismatch():
+    with pytest.raises(ValidationError, match="same length"):
+
+        @squin.kernel
+        def main():
+            q = squin.qalloc(3)
+            ps = [
+                0.0001,
+                0.0001,
+                0.0001,
+                0.0001,
+                0.0001,
+                0.0001,
+                0.0001,
+                0.0001,
+                0.0001,
+                0.0001,
+                0.0001,
+                0.0001,
+                0.0001,
+                0.0001,
+                0.0001,
+            ]
+            squin.broadcast.two_qubit_pauli_channel(ps, [q[0], q[1]], [q[2]])
 
 
 def test_two_qubit_pauli_channel_shorthand_rejects_runtime_lists():


### PR DESCRIPTION
Define a custom lowering pass (`FromPythonCallTwoQubitPauliChannelSimple`) on a new statement (`TwoQubitPauliChannelSimple`) that lowers

```
squin.two_qubit_pauli_channel(paulis, probs, q[0], q[1])
```

to a `TwoQubitPauliChannel`.

The `FromPythonCallTwoQubitPauliChannel` custom lowering has two responsibilities (because it supports the 'broadcast'ed version of the statement AND the syntactic sugar):
1. Checks if the 'control'/'target' argument is a single qubit or a list of qubits.
2. Checks if the user passes one argument (`probabilities`) or two arguments (`paulis`, `probabilities`) and parses the latter "syntactic sugar" case accordingly.

Also attempted an implementation for the broadcasted version.

Due to the broadcasted version, for the `TwoQubitPauliChannel` statement, changed the typevar for the length for the `controls` and `targets` iList to be `Any` instead of `N`, but added check() statements to check the static lengths.