### PR TITLE
Add Lost-aware XOR for measurement results

### DIFF
--- a/src/bloqade/pyqrack/reg.py
+++ b/src/bloqade/pyqrack/reg.py
@@ -2,8 +2,8 @@ import enum
 from typing import TYPE_CHECKING
 from dataclasses import dataclass
 
+from bloqade.types import MeasurementResultValue
 from bloqade.qasm2.types import Qubit
-from bloqade.decoders.dialects.annotate.types import MeasurementResultValue
 
 if TYPE_CHECKING:
     from pyqrack import QrackSimulator

--- a/src/bloqade/qubit/__init__.py
+++ b/src/bloqade/qubit/__init__.py
@@ -1,6 +1,7 @@
 from bloqade.types import Qubit as Qubit, QubitType as QubitType
 
 from . import stmts as stmts, analysis as analysis
+from . import _typeinfer_binop as _typeinfer_binop
 from .stdlib import new as new, qalloc as qalloc, broadcast as broadcast
 from ._dialect import dialect as dialect
 from ._prelude import kernel as kernel

--- a/src/bloqade/qubit/_typeinfer_binop.py
+++ b/src/bloqade/qubit/_typeinfer_binop.py
@@ -1,0 +1,15 @@
+"""Type inference overlay for BitXor on MeasurementResult."""
+
+from kirin import interp
+from kirin.dialects import py
+from kirin.dialects.py.binop.typeinfer import TypeInfer
+
+from bloqade.types import MeasurementResultType
+
+
+@interp.impl(py.BitXor, MeasurementResultType, MeasurementResultType)
+def bitxor_measurement(self, interp_, frame, stmt):
+    return (MeasurementResultType,)
+
+
+TypeInfer.bitxor_measurement = bitxor_measurement

--- a/src/bloqade/types.py
+++ b/src/bloqade/types.py
@@ -12,7 +12,64 @@ from kirin.dialects.ilist import IList
 from bloqade.decoders.dialects.annotate.types import (
     MeasurementResult as MeasurementResult,
     MeasurementResultType as MeasurementResultType,
+    MeasurementResultValue as MeasurementResultValue,
 )
+
+
+def _as_measurement_value(
+    other: Any,
+) -> MeasurementResultValue | None:
+    if isinstance(other, MeasurementResult):
+        return other.value
+    if isinstance(other, MeasurementResultValue):
+        return other
+    return None
+
+
+def _xor_measurement_values(
+    lhs: MeasurementResultValue, rhs: MeasurementResultValue
+) -> MeasurementResultValue:
+    if lhs is MeasurementResultValue.Lost or rhs is MeasurementResultValue.Lost:
+        return MeasurementResultValue.Lost
+    return MeasurementResultValue(int(lhs) ^ int(rhs))
+
+
+def _measurement_value_xor(
+    self: MeasurementResultValue, other: Any
+) -> MeasurementResultValue:
+    rhs = _as_measurement_value(other)
+    if rhs is None:
+        return NotImplemented
+    return _xor_measurement_values(self, rhs)
+
+
+def _measurement_value_rxor(
+    self: MeasurementResultValue, other: Any
+) -> MeasurementResultValue:
+    lhs = _as_measurement_value(other)
+    if lhs is None:
+        return NotImplemented
+    return _xor_measurement_values(lhs, self)
+
+
+def _measurement_result_xor(self: MeasurementResult, other: Any) -> MeasurementResult:
+    rhs = _as_measurement_value(other)
+    if rhs is None:
+        return NotImplemented
+    return MeasurementResult(_xor_measurement_values(self.value, rhs))
+
+
+def _measurement_result_rxor(self: MeasurementResult, other: Any) -> MeasurementResult:
+    lhs = _as_measurement_value(other)
+    if lhs is None:
+        return NotImplemented
+    return MeasurementResult(_xor_measurement_values(lhs, self.value))
+
+
+MeasurementResultValue.__xor__ = _measurement_value_xor  # type: ignore[method-assign]
+MeasurementResultValue.__rxor__ = _measurement_value_rxor  # type: ignore[method-assign]
+MeasurementResult.__xor__ = _measurement_result_xor  # type: ignore[method-assign]
+MeasurementResult.__rxor__ = _measurement_result_rxor  # type: ignore[method-assign]
 
 
 class Qubit(ABC):

--- a/test/pyqrack/squin/test_measurement_xor.py
+++ b/test/pyqrack/squin/test_measurement_xor.py
@@ -1,0 +1,35 @@
+from bloqade import squin
+from bloqade.pyqrack import StackMemorySimulator, MeasurementResultValue
+
+
+def test_measurement_xor_parity():
+    @squin.kernel
+    def one_xor_zero():
+        q = squin.qalloc(2)
+        squin.x(q[0])
+        return squin.measure(q[0]) ^ squin.measure(q[1])
+
+    @squin.kernel
+    def one_xor_one():
+        q = squin.qalloc(2)
+        squin.x(q[0])
+        squin.x(q[1])
+        return squin.measure(q[0]) ^ squin.measure(q[1])
+
+    sim = StackMemorySimulator(min_qubits=2)
+    assert sim.run(one_xor_zero) is MeasurementResultValue.One
+    assert sim.run(one_xor_one) is MeasurementResultValue.Zero
+
+
+def test_measurement_xor_with_loss_is_lost():
+    @squin.kernel
+    def xor_after_loss():
+        q = squin.qalloc(2)
+        squin.qubit_loss(1.0, q[0])
+        return squin.measure(q[0]) ^ squin.measure(q[1])
+
+    sim = StackMemorySimulator(
+        min_qubits=2,
+        loss_m_result=MeasurementResultValue.Lost,
+    )
+    assert sim.run(xor_after_loss) is MeasurementResultValue.Lost

--- a/test/squin/test_typeinfer.py
+++ b/test/squin/test_typeinfer.py
@@ -95,3 +95,15 @@ def test_typeinfer_measure():
         return squin.measure(q)
 
     assert wrong.return_type.is_subseteq(Bottom)
+
+
+def test_typeinfer_measurement_xor():
+    @squin.kernel
+    def xor_meas():
+        q = squin.qalloc(2)
+        m0 = squin.measure(q[0])
+        m1 = squin.measure(q[1])
+        return m0 ^ m1
+
+    assert xor_meas.return_type.is_structurally_equal(MeasurementResultType)
+    assert not xor_meas.return_type.is_subseteq(Bottom)

--- a/test/test_measurement_xor.py
+++ b/test/test_measurement_xor.py
@@ -1,0 +1,57 @@
+"""Lost-aware XOR on measurement outcomes."""
+
+import pytest
+
+from bloqade.types import MeasurementResult, MeasurementResultValue
+
+Zero = MeasurementResultValue.Zero
+One = MeasurementResultValue.One
+Lost = MeasurementResultValue.Lost
+
+
+@pytest.mark.parametrize(
+    ("lhs", "rhs", "expected"),
+    [
+        (Zero, Zero, Zero),
+        (Zero, One, One),
+        (One, Zero, One),
+        (One, One, Zero),
+        (Lost, Zero, Lost),
+        (Lost, One, Lost),
+        (Zero, Lost, Lost),
+        (One, Lost, Lost),
+        (Lost, Lost, Lost),
+    ],
+)
+def test_measurement_value_xor(lhs, rhs, expected):
+    assert lhs ^ rhs is expected
+
+
+@pytest.mark.parametrize(
+    ("lhs", "rhs", "expected"),
+    [
+        (Zero, Zero, Zero),
+        (Zero, One, One),
+        (One, One, Zero),
+        (Lost, One, Lost),
+        (One, Lost, Lost),
+    ],
+)
+def test_measurement_result_xor(lhs, rhs, expected):
+    result = MeasurementResult(lhs) ^ MeasurementResult(rhs)
+    assert isinstance(result, MeasurementResult)
+    assert result.value is expected
+
+
+def test_mixed_measurement_result_and_value_xor():
+    assert MeasurementResult(One) ^ Zero == MeasurementResult(One)
+    assert One ^ MeasurementResult(One) is Zero
+    assert MeasurementResult(Lost) ^ One == MeasurementResult(Lost)
+    assert Lost ^ MeasurementResult(Zero) is Lost
+
+
+def test_measurement_result_xor_rejects_unrelated_types():
+    with pytest.raises(TypeError):
+        MeasurementResult(Zero) ^ 1
+    with pytest.raises(TypeError):
+        MeasurementResult(Zero) ^ "0"


### PR DESCRIPTION
Allow meas[0] ^ meas[1] outside and inside kernels, returning Lost if either operand is Lost.