### PR TITLE
Start 0.16.0-DEV development

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bloqade-circuit"
-version = "0.15.0-DEV"
+version = "0.16.0-DEV"
 description = "The software development toolkit for neutral atom arrays."
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -141,7 +141,7 @@ wheels = [
 
 [[package]]
 name = "bloqade-circuit"
-version = "0.15.0.dev0"
+version = "0.16.0.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "bloqade-decoders" },


### PR DESCRIPTION
Post-release bump of bloqade-circuit to 0.16.0-DEV after cutting 0.15.0 (tag v0.15.0, live on PyPI).